### PR TITLE
Use .NET 9's System.Threading.Lock instead of object for locking

### DIFF
--- a/SharpCoreDB.Benchmarks/FairComparisonBenchmark.cs
+++ b/SharpCoreDB.Benchmarks/FairComparisonBenchmark.cs
@@ -187,7 +187,7 @@ public class FairComparisonBenchmark
         {
             var perThread = RECORDS / threads;
             var tasks = new Task[threads];
-            var lockObj = new object();
+            Lock lockObj = new();
 
             for (int t = 0; t < threads; t++)
             {

--- a/SharpCoreDB.Extensions/DapperPerformanceExtensions.cs
+++ b/SharpCoreDB.Extensions/DapperPerformanceExtensions.cs
@@ -11,7 +11,7 @@ namespace SharpCoreDB.Extensions;
 public static class DapperPerformanceExtensions
 {
     private static readonly Dictionary<string, PerformanceMetrics> _metricsCache = new();
-    private static readonly object _metricsLock = new();
+    private static readonly Lock _metricsLock = new();
 
     /// <summary>
     /// Executes a query with performance tracking.

--- a/SharpCoreDB/Database.Core.cs
+++ b/SharpCoreDB/Database.Core.cs
@@ -36,7 +36,7 @@ public partial class Database : IDatabase, IDisposable
     private readonly DatabaseConfig? config;
     private readonly QueryCache? queryCache;
     private readonly PageCache? pageCache;
-    private readonly object _walLock = new();  // ✅ C# 14: target-typed new
+    private readonly Lock _walLock = new();  // ✅ C# 14: target-typed new
     private readonly ConcurrentDictionary<string, CachedQueryPlan> _preparedPlans = new();
     
     private readonly GroupCommitWAL? groupCommitWal;

--- a/SharpCoreDB/MVCC/MvccManager.cs
+++ b/SharpCoreDB/MVCC/MvccManager.cs
@@ -23,7 +23,7 @@ public sealed class MvccManager<TKey, TData> : IDisposable
     private readonly ConcurrentDictionary<long, MvccTransaction> _activeTransactions = new();
     private long _currentVersion;
     private long _nextTransactionId;
-    private readonly object _versionLock = new();
+    private readonly Lock _versionLock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MvccManager{TKey, TData}"/> class.

--- a/SharpCoreDB/MVCC/VersionedRow.cs
+++ b/SharpCoreDB/MVCC/VersionedRow.cs
@@ -69,7 +69,7 @@ public sealed record VersionedRow<TData>(
 public sealed class VersionChain<TData> where TData : class
 {
     private readonly List<VersionedRow<TData>> _versions = [];
-    private readonly object _lock = new();
+    private readonly Lock _lock = new();
 
     /// <summary>
     /// Gets the number of versions in this chain.

--- a/SharpCoreDB/Optimizations/InsertOptimizations.cs
+++ b/SharpCoreDB/Optimizations/InsertOptimizations.cs
@@ -22,7 +22,7 @@ public static class InsertOptimizations
     {
         private readonly List<Dictionary<string, object>> _rowBuffer = [];
         private bool _isTransposed;
-        private readonly object _transposeLock = new();
+        private readonly Lock _transposeLock = new();
 
         /// <summary>
         /// Adds a row WITHOUT transposing (O(1) operation).

--- a/SharpCoreDB/Services/AutoMaintenanceService.cs
+++ b/SharpCoreDB/Services/AutoMaintenanceService.cs
@@ -16,7 +16,7 @@ public class AutoMaintenanceService : IDisposable
     private readonly System.Timers.Timer timer;
     private int writeCount = 0;
     private readonly int writeThreshold;
-    private readonly object @lock = new();
+    private readonly Lock @lock = new();
     private bool disposed = false;
 
     /// <summary>

--- a/SharpCoreDB/Services/Storage.Append.cs
+++ b/SharpCoreDB/Services/Storage.Append.cs
@@ -21,7 +21,7 @@ public partial class Storage
     // Track buffered appends during transaction
     private readonly Dictionary<string, List<(byte[] data, long position)>> bufferedAppends = new();
     private readonly Dictionary<string, long> cachedFileLengths = new();  // ✅ NEW: Cache file lengths
-    private readonly object appendLock = new object();
+    private readonly Lock appendLock = new();
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]

--- a/SharpCoreDB/Services/Storage.Core.cs
+++ b/SharpCoreDB/Services/Storage.Core.cs
@@ -27,7 +27,7 @@ public partial class Storage : IStorage
     
     // Transaction support
     private readonly TransactionBuffer transactionBuffer;
-    private readonly object transactionLock = new object();
+    private readonly Lock transactionLock = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Storage"/> class.

--- a/SharpCoreDB/SharpCoreDB/Core/File/BufferedWriteManager.cs
+++ b/SharpCoreDB/SharpCoreDB/Core/File/BufferedWriteManager.cs
@@ -19,7 +19,7 @@ public class BufferedWriteManager : IDisposable
 {
     // Per-file buffered writes
     private readonly Dictionary<string, FileWriteBuffer> fileBuffers = [];
-    private readonly object bufferLock = new object();
+    private readonly Lock bufferLock = new();
     
     private bool disposed = false;
 

--- a/SharpCoreDB/Storage/Engines/PageBasedEngine.cs
+++ b/SharpCoreDB/Storage/Engines/PageBasedEngine.cs
@@ -27,7 +27,7 @@ public class PageBasedEngine : IStorageEngine
     private readonly string databasePath;
     private readonly ConcurrentDictionary<string, PageManager> tableManagers = new();
     private readonly ConcurrentDictionary<string, uint> tableIds = new();
-    private readonly object transactionLock = new();
+    private readonly Lock transactionLock = new();
     private bool isInTransaction;
     private readonly List<Action> transactionActions = new();
     

--- a/SharpCoreDB/Storage/PageManager.cs
+++ b/SharpCoreDB/Storage/PageManager.cs
@@ -25,7 +25,7 @@ public class PageManager : IDisposable
     private readonly string freeListFilePath;
     private readonly FileStream pagesFile;
     private readonly ConcurrentDictionary<ulong, Page> pageCache;
-    private readonly object writeLock = new();
+    private readonly Lock writeLock = new();
 #pragma warning disable S1144 // disposed field used in Dispose pattern
     private bool disposed;
 #pragma warning restore S1144


### PR DESCRIPTION
This will give higher performance. I left one part out since I was not sure how you wanted to proceed, locking on the `PooledDatabase` instance. We could create a `Lock` instance for it too but it may or may not lead to a performance improvement.