### PR TITLE
docs: fix stale compression references after v1.9.8

### DIFF
--- a/.github/CODING_STANDARDS_CSHARP14.md
+++ b/.github/CODING_STANDARDS_CSHARP14.md
@@ -751,7 +751,7 @@ await WriteBatchAsync(operations);
 var checksum = SHA256.HashData(data.Span);
 
 // ✅ Mark TODO items
-// TODO: Implement compression for blocks > 1MB
+// TODO: Add streaming compression for blocks > 16MB (avoid full payload in memory)
 
 // ✅ Mark performance-critical sections
 // PERF: Hot path - avoid allocations

--- a/docs/serialization/BINARY_FORMAT_VISUAL_REFERENCE.md
+++ b/docs/serialization/BINARY_FORMAT_VISUAL_REFERENCE.md
@@ -55,7 +55,7 @@ Offset   Size   Field Name                Value
 0x000C   4      HeaderSize                512 (always)
 
 0x0010   1      EncryptionMode            0=None, 1=AES-256-GCM
-0x0011   1      CompressionMode           0=None (reserved)
+0x0011   1      CompressionMode           0=None, 1=Brotli, 2=GZip
 0x0012   2      EncryptionKeyId           Key derivation ID
 0x0014   12     Nonce                     AES-GCM nonce
 

--- a/docs/serialization/SERIALIZATION_AND_STORAGE_GUIDE.md
+++ b/docs/serialization/SERIALIZATION_AND_STORAGE_GUIDE.md
@@ -31,7 +31,7 @@ SharpCoreDB uses a **single-file binary format** (`.scdb`) for persistent storag
 | **String Storage** | Variable-length; prefixed with 4-byte length field |
 | **No Fixed-Length Requirement** | Strings can be arbitrarily long (limited by available disk space) |
 | **Encryption** | Optional AES-256-GCM |
-| **Compression** | Not implemented (reserved in header) |
+| **Compression** | Optional Brotli/GZip block-level compression (see `BlockCompressionMode`) |
 
 ---
 
@@ -89,7 +89,7 @@ public struct ScdbFileHeader
 
     // === Encryption (16 bytes) ===
     public byte EncryptionMode;   // 0x0010: 0=None, 1=AES-256-GCM
-    public byte CompressionMode;  // 0x0011: Reserved (always 0)
+    public byte CompressionMode;  // 0x0011: 0=None, 1=Brotli, 2=GZip (see BlockCompressionMode)
     public ushort EncryptionKeyId;// 0x0012: Key derivation ID
     public fixed byte Nonce[12];  // 0x0014: AES-GCM nonce
 

--- a/src/SharpCoreDB/Storage/Scdb/ScdbStructures.cs
+++ b/src/SharpCoreDB/Storage/Scdb/ScdbStructures.cs
@@ -1,4 +1,4 @@
-// <copyright file="ScdbStructures.cs" company="MPCoreDeveloper">
+// src\SharpCoreDB\Storage\Scdb\ScdbStructures.cs
 // Copyright (c) 2025-2026 MPCoreDeveloper and GitHub Copilot. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
@@ -38,8 +38,8 @@ public struct ScdbFileHeader
     /// <summary>Encryption mode: 0=None, 1=AES-256-GCM</summary>
     public byte EncryptionMode;   // 0x0010: Encryption mode
     
-    /// <summary>Compression mode: 0=None (always 0 for .scdb)</summary>
-    public byte CompressionMode;  // 0x0011: Compression (unused)
+    /// <summary>Compression mode: 0=None, 1=Brotli, 2=GZip (see BlockCompressionMode)</summary>
+    public byte CompressionMode;  // 0x0011: Block compression mode
     
     /// <summary>Key derivation ID for encryption</summary>
     public ushort EncryptionKeyId;// 0x0012: Key derivation ID
@@ -443,7 +443,8 @@ public enum BlockFlags : uint
     /// <summary>Block has uncommitted changes</summary>
     Dirty = 1 << 0,
     
-    /// <summary>Block is compressed (reserved, always 0 for .scdb)</summary>
+    /// <summary>Block is compressed (Brotli or GZip, see BlockCompressionMode)</summary>
+
     Compressed = 1 << 1,
     
     /// <summary>Block is encrypted with AES-256-GCM</summary>


### PR DESCRIPTION
## Summary

Updates documentation and code comments that still described block compression as "not implemented" or "reserved" despite being shipped in v1.9.8 (PR #344).

## Changes

- `docs/serialization/SERIALIZATION_AND_STORAGE_GUIDE.md` — Updated compression table row and header field comment
- `docs/serialization/BINARY_FORMAT_VISUAL_REFERENCE.md` — Updated `CompressionMode` field description
- `src/SharpCoreDB/Storage/Scdb/ScdbStructures.cs` — Updated `CompressionMode` field XML doc and inline comment; updated `BlockFlags.Compressed` enum doc
- `.github/CODING_STANDARDS_CSHARP14.md` — Updated stale TODO to reflect remaining streaming-compression work

## Context

These references were left stale after PR #344 merged block-level Brotli/GZip compression. This PR cleans up the documentation to match the shipped feature.