### PR TITLE
fix(update): re-point hash indexes in batch in-place UPDATE fastPatch (stale-index bug)

### DIFF
--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -1927,6 +1927,22 @@ public partial class Table
                     this.TableCheckConstraints.Count == 0 &&
                     !HasColumnCheckConstraints();
 
+                // The raw-byte patch writes the record in place without re-pointing hash indexes, so
+                // when the update touches a hash-indexed column those entries must be re-pointed
+                // explicitly (old key removed, new key added at the same position) after the write.
+                bool touchesHashIndexedColumn = false;
+                if (this.hashIndexes.Count > 0)
+                {
+                    foreach (var updateKey in updates.Keys)
+                    {
+                        if (this.hashIndexes.ContainsKey(updateKey))
+                        {
+                            touchesHashIndexedColumn = true;
+                            break;
+                        }
+                    }
+                }
+
                 // Resolve matching rows as (storage position, row, raw bytes) so the columnar
                 // write path can patch fields in place even when the table has no primary key.
                 // The position comes from the hash index / PK lookup already performed here; in
@@ -2039,8 +2055,34 @@ public partial class Table
                             ? TryOverwriteFixedWidthInPlace(rawData, updates)
                             : TryOverwriteFieldsInPlaceActual(rawData, updates);
 
-                        if (patched is not null && engine.TryUpdateInPlace(Name, rowPosition, patched))
+                        if (patched is not null && engine.TryUpdateInPlaceSameLength(Name, rowPosition, patched))
                         {
+                            // The record was overwritten in place; when the update changed a
+                            // hash-indexed column, re-point its entries (old key decoded from the
+                            // pre-write row bytes, new key added at the same position). Non-indexed
+                            // updates skip this entirely.
+                            if (touchesHashIndexedColumn)
+                            {
+                                var oldRow = DeserializeRow(rawData);
+                                if (oldRow is not null)
+                                {
+                                    foreach (var (colName, hashIdx) in this.hashIndexes)
+                                    {
+                                        if (!updates.TryGetValue(colName, out var newVal) || newVal is null)
+                                        {
+                                            continue;
+                                        }
+
+                                        if (oldRow.TryGetValue(colName, out var oldVal) && oldVal is not null)
+                                        {
+                                            hashIdx.Remove(oldVal, rowPosition);
+                                        }
+
+                                        hashIdx.Add(newVal, rowPosition);
+                                    }
+                                }
+                            }
+
                             continue;
                         }
 

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -105,6 +105,15 @@ public interface IStorage
     bool OverwriteRecordAt(string path, long offset, byte[] data);
 
     /// <summary>
+    /// Like <see cref="OverwriteRecordAt"/> for the case where the caller guarantees
+    /// <paramref name="data"/> has the same byte length as the stored record payload (an in-place
+    /// field patch built from the existing row). Implementations may skip the length-prefix
+    /// read/verification; the default routes to <see cref="OverwriteRecordAt"/>.
+    /// </summary>
+    bool OverwriteRecordAtSameLength(string path, long offset, byte[] data) =>
+        OverwriteRecordAt(path, offset, data);
+
+    /// <summary>
     /// Appends multiple binary data blocks to a file in a single batch operation (used for batch inserts).
     /// </summary>
     /// <param name="path">The file path.</param>

--- a/src/SharpCoreDB/Interfaces/IStorageEngine.cs
+++ b/src/SharpCoreDB/Interfaces/IStorageEngine.cs
@@ -56,6 +56,16 @@ public interface IStorageEngine : IDisposable
     bool TryUpdateInPlace(string tableName, long storageReference, byte[] newData);
 
     /// <summary>
+    /// Same contract as <see cref="TryUpdateInPlace"/> for the common case where the caller has
+    /// already read the existing record and guarantees <paramref name="newData"/> has the exact same
+    /// byte length as the stored payload (e.g. an in-place field patch built from the existing row).
+    /// Engines that can use the guarantee skip the extra length-prefix read; the default routes to
+    /// <see cref="TryUpdateInPlace"/> so existing implementations keep working unchanged.
+    /// </summary>
+    bool TryUpdateInPlaceSameLength(string tableName, long storageReference, byte[] newData) =>
+        TryUpdateInPlace(tableName, storageReference, newData);
+
+    /// <summary>
     /// Deletes a record at the specified storage reference.
     /// </summary>
     /// <param name="tableName">Name of the table.</param>

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -465,26 +465,43 @@ public partial class Storage
             }
 
             // B7: inside a transaction, buffer the overwrite (write-behind) instead of writing to
-            // disk per row. Only records already flushed to disk (offset below the buffered-appends
-            // boundary) can be overwritten in place; still-buffered records fall back to append.
-            // Because nothing is written to disk until commit, the original bytes remain intact and
-            // rollback needs no undo data.
+            // disk per row; outside one, write it immediately. Nothing is written to disk before
+            // commit in the transactional case, so rollback needs no undo data.
+            return BufferOrWriteOverwriteInPlace(path, offset, record);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// B7: buffers (inside a transaction) or writes (outside one) an in-place overwrite of a
+    /// length-prefixed record whose payload is <paramref name="record"/> (already encrypted when
+    /// applicable). The caller guarantees the new payload length equals the stored payload length,
+    /// so no length-prefix read/verification is needed.
+    /// </summary>
+    private bool BufferOrWriteOverwriteInPlace(string path, long offset, byte[] record)
+    {
+        bool inTransaction = IsInTransaction;
+        int recordLength = record.Length;
+
+        try
+        {
             if (inTransaction)
             {
+                // Only records already flushed to disk (offset below the buffered-appends boundary)
+                // can be overwritten in place; still-buffered records fall back to append.
                 if (!bufferedFileBaseLengths.TryGetValue(path, out long baseLength))
                 {
                     baseLength = File.Exists(path) ? new FileInfo(path).Length : 0;
                     bufferedFileBaseLengths[path] = baseLength;
                 }
 
-                if (offset + 4 + existingLength > baseLength)
+                if (offset + 4 + recordLength > baseLength)
                 {
                     return false;
                 }
-
-                byte[] newRecord = new byte[4 + record.Length];
-                BinaryPrimitives.WriteInt32LittleEndian(newRecord, record.Length);
-                record.CopyTo(newRecord.AsSpan(4));
 
                 lock (appendLock)
                 {
@@ -494,22 +511,15 @@ public partial class Storage
                         bufferedOverwrites[path] = overwrites;
                     }
 
-                    overwrites[offset] = newRecord;
+                    overwrites[offset] = record;
                 }
-
-                // Invalidate app-level page cache (mirrors AppendBytes).
-                if (this.pageCache != null)
-                {
-                    int pageId = ComputePageId(path, offset);
-                    this.pageCache.EvictPage(pageId);
-                }
-
-                return true;
             }
-
-            // Outside a transaction: overwrite the record on disk immediately.
-            BinaryPrimitives.WriteInt32LittleEndian(lengthBuffer, recordLength);
-            WriteRecordInPlace(path, offset, lengthBuffer, record);
+            else
+            {
+                Span<byte> lengthBuffer = stackalloc byte[4];
+                BinaryPrimitives.WriteInt32LittleEndian(lengthBuffer, recordLength);
+                WriteRecordInPlace(path, offset, lengthBuffer, record);
+            }
         }
         catch (IOException)
         {
@@ -526,7 +536,27 @@ public partial class Storage
         return true;
     }
 
+    /// <summary>
+    /// Overwrites a length-prefixed record in place at <paramref name="offset"/> when the caller
+    /// guarantees the new plaintext payload has the same length as the stored one (e.g. an in-place
+    /// field patch built from the existing record bytes). Skips the length-prefix read/verification
+    /// that <see cref="OverwriteRecordAt"/> performs — one less per-row syscall in the batch-DML
+    /// hot path.
+    /// </summary>
+    /// <param name="path">The table data file path.</param>
+    /// <param name="offset">The physical file offset of the record's 4-byte length prefix.</param>
+    /// <param name="data">The plaintext record data to write (same length as the stored payload).</param>
+    /// <returns>True when the record was overwritten/buffered in place.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public bool OverwriteRecordAtSameLength(string path, long offset, byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
 
+        bool encryptWrites = ShouldEncryptWrites(path);
+        byte[] record = EncryptRecord(data, encryptWrites);
+
+        return BufferOrWriteOverwriteInPlace(path, offset, record);
+    }
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
@@ -765,9 +795,11 @@ public partial class Storage
 
             try
             {
-                foreach (var (offset, newRecord) in overwrites)
+                Span<byte> lengthPrefix = stackalloc byte[4];
+                foreach (var (offset, record) in overwrites)
                 {
-                    WriteRecordInPlace(path, offset, newRecord.AsSpan(0, 4), newRecord.AsSpan(4));
+                    BinaryPrimitives.WriteInt32LittleEndian(lengthPrefix, record.Length);
+                    WriteRecordInPlace(path, offset, lengthPrefix, record);
                 }
             }
             catch (IOException)
@@ -784,18 +816,17 @@ public partial class Storage
     public byte[]? ReadBytesFrom(string path, long offset)
     {
         // B7: inside a transaction, a buffered in-place overwrite takes precedence over the disk
-        // version (the overwrite is written to disk only at commit).
+        // version (the overwrite is written to disk only at commit). The buffer holds the payload
+        // only (its length is the record's stored length).
         if (!bufferedOverwrites.IsEmpty &&
             bufferedOverwrites.TryGetValue(path, out var buffered) &&
             buffered.TryGetValue(offset, out var newRecord) &&
             newRecord.Length > 0)
         {
-            int bufferedLength = BinaryPrimitives.ReadInt32LittleEndian(newRecord);
-            if (bufferedLength > 0 && bufferedLength <= MaxRecordSize &&
-                newRecord.Length >= 4 + bufferedLength)
+            if (newRecord.Length <= MaxRecordSize)
             {
-                byte[] bufferedPayload = new byte[bufferedLength];
-                Buffer.BlockCopy(newRecord, 4, bufferedPayload, 0, bufferedLength);
+                byte[] bufferedPayload = new byte[newRecord.Length];
+                Buffer.BlockCopy(newRecord, 0, bufferedPayload, 0, newRecord.Length);
 
                 if (UseRecordEncryption && FileHasEncryptedHeader(path))
                 {

--- a/src/SharpCoreDB/Storage/Engines/AppendOnlyEngine.cs
+++ b/src/SharpCoreDB/Storage/Engines/AppendOnlyEngine.cs
@@ -132,6 +132,26 @@ public class AppendOnlyEngine : IStorageEngine
         return overwritten;
     }
 
+    /// <inheritdoc />
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public bool TryUpdateInPlaceSameLength(string tableName, long storageReference, byte[] newData)
+    {
+        ArgumentNullException.ThrowIfNull(newData);
+
+        // Caller guarantees newData has the same payload length as the stored record (in-place field
+        // patch), so the storage layer skips the length-prefix read/verification.
+        var filePath = GetTableFilePath(tableName);
+        bool overwritten = storage.OverwriteRecordAtSameLength(filePath, storageReference, newData);
+
+        if (overwritten)
+        {
+            Interlocked.Increment(ref totalUpdates);
+            Interlocked.Add(ref bytesWritten, newData.Length);
+        }
+
+        return overwritten;
+    }
+
 
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

Cherry-pick of the phase-1 in-place batch-UPDATE fix (from `perf/fixedwidth-backport` `08bd7eb2`) to the v2.1 line.

## Why

Measurement (probe replicating the comparative harness UPDATE workload) showed the B7 raw-byte `fastPatch` in `Table.UpdateMultiple` ran without write-amplification (0 file growth) but left **stale hash-index entries** whenever the update touched an auto-indexed column (`EnableHashIndexes=true` indexes every column): after `UPDATE docs SET score = …`, a query on the **new** score value returned nothing and the old value still matched. That is a data-integrity bug.

## What changes

- `Table.CRUD.cs` fastPatch: after a successful same-length in-place write, **re-point every hash index whose column the update changed** (old key decoded from the pre-write row bytes, new key added at the same position). The fast path is kept.
- `Storage.Append.cs`: buffer in-place overwrites payload-only (no `[4+len]` copy per row); extracted `BufferOrWriteOverwriteInPlace`; new `OverwriteRecordAtSameLength` skips the per-row length-prefix read when the caller guarantees same length.
- `IStorage` / `IStorageEngine`: additive default methods `OverwriteRecordAtSameLength` / `TryUpdateInPlaceSameLength` (default routes to the verified path; `AppendOnlyEngine` uses the fast path).

## Validation (net11)

- Build: 0 errors.
- 222 targeted DML / fixed-width / indexing / storage-engine tests green.
- Probe on net10 (master line): UPDATE batch 28.3K → 33.8K ops/s, 0 file growth, and after updating an auto-indexed column the index returns the new value (0 mismatches in 1000 point-reads).
