### PR TITLE
build(v2.1): pin SDK global.json to the full preview.7 build (fixes CI download)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.7",
+    "version": "11.0.100-preview.7.26381.103",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }

--- a/src/SharpCoreDB/global.json
+++ b/src/SharpCoreDB/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.7",
+    "version": "11.0.100-preview.7.26381.103",
     "rollForward": "latestFeature",
     "allowPrerelease": true
   }


### PR DESCRIPTION
## Summary

Fixes the v2.1 CI `submit-nuget` failure: GitHub Actions `setup-dotnet` (via the `global.json`-based install) could not resolve `11.0.100-preview.7` because the SDK artifact is hosted under the **full build number** (`builds.dotnet.microsoft.com/dotnet/Sdk/11.0.100-preview.7.26381.103/...`). The short version is no longer mapped by `dotnet-install`, so the download 404'd.

## Change

Pin both `global.json` files (`./` and `src/SharpCoreDB/`) to the exact, downloadable build **`11.0.100-preview.7.26381.103`** (currently the latest .NET 11 SDK per the official 11.0 channel metadata; the artifact URL was verified HTTP 200).

`rollForward: latestFeature` + `allowPrerelease: true` are kept, so once a newer .NET 11 preview/RC or GA ships it will be picked up automatically.
