### PR TITLE
bench: add fixed-width variant to the fair PK comparison

### DIFF
--- a/tests/benchmarks/SharpCoreDB.Benchmarks.Comparative/Program.cs
+++ b/tests/benchmarks/SharpCoreDB.Benchmarks.Comparative/Program.cs
@@ -353,6 +353,10 @@ class Program
         {
             NoEncryptMode = true,
             StorageEngineType = engineType,
+            // The fair PK comparison intentionally isolates the record-layout variable: the legacy
+            // arm opts out of the AutoFixedWidthRecords default so it measures true variable-length
+            // records; the fixed-width arm forces FixedWidthRecordLayout.
+            AutoFixedWidthRecords = !fixedWidth,
             FixedWidthRecordLayout = fixedWidth,
             UseGroupCommitWal = false,
             EnableAdaptiveWalBatching = false,

--- a/tests/benchmarks/SharpCoreDB.Benchmarks.Comparative/Program.cs
+++ b/tests/benchmarks/SharpCoreDB.Benchmarks.Comparative/Program.cs
@@ -347,12 +347,13 @@ class Program
         Console.WriteLine($"  SQL/Direct overhead: {(sqlMedian / directMedian):F2}x");
     }
 
-    static DatabaseConfig BuildConfig(SharpCoreDB.Interfaces.StorageEngineType engineType)
+    static DatabaseConfig BuildConfig(SharpCoreDB.Interfaces.StorageEngineType engineType, bool fixedWidth = false)
     {
         return new DatabaseConfig
         {
             NoEncryptMode = true,
             StorageEngineType = engineType,
+            FixedWidthRecordLayout = fixedWidth,
             UseGroupCommitWal = false,
             EnableAdaptiveWalBatching = false,
             HighSpeedInsertMode = true,
@@ -840,7 +841,7 @@ class Program
     /// <c>ExecuteBatchSQL</c> (single transaction). This exercises the PK B-tree fast paths and the
     /// recommended usage; the no-PK harness scenario above under-measures the engine on DML.
     /// </summary>
-    static BenchmarkResult RunSharpCoreDBPk(SharpCoreDB.Interfaces.StorageEngineType engineType)
+    static BenchmarkResult RunSharpCoreDBPk(SharpCoreDB.Interfaces.StorageEngineType engineType, bool fixedWidth = false)
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"bench-sharpcoredb-pk-{Guid.NewGuid()}");
         var result = new BenchmarkResult();
@@ -852,7 +853,7 @@ class Program
             var sp = services.BuildServiceProvider();
 
             var factory = sp.GetRequiredService<DatabaseFactory>();
-            var config = BuildConfig(engineType);
+            var config = BuildConfig(engineType, fixedWidth);
 
             using var db = (SharpCoreDB.Database)factory.Create(
                 dbPath: dbPath,
@@ -962,8 +963,12 @@ class Program
         Console.WriteLine();
         Console.WriteLine($"Engine: {engineLabel}");
 
-        Console.WriteLine("━━━ SharpCoreDB (SQL, PK) ━━━");
+        Console.WriteLine("━━━ SharpCoreDB (SQL, PK, legacy variable-length) ━━━");
         var scdb = RunSharpCoreDBPk(engineType);
+        Console.WriteLine();
+
+        Console.WriteLine("━━━ SharpCoreDB (SQL, PK, fixed-width) ━━━");
+        var scdbFw = RunSharpCoreDBPk(engineType, fixedWidth: true);
         Console.WriteLine();
 
         Console.WriteLine("━━━ SQLite (reference) ━━━");
@@ -972,12 +977,15 @@ class Program
 
         Console.WriteLine("║ Database      │ INSERT     │ READ     │ UPDATE   │ DELETE   ║");
         Console.WriteLine($"║ SharpCoreDB   │ {scdb.InsertOpsPerSec,10:N0} │ {scdb.ReadOpsPerSec,8:N0} │ {scdb.UpdateOpsPerSec,8:N0} │ {scdb.DeleteOpsPerSec,8:N0} ║");
+        Console.WriteLine($"║ SharpCoreDB FW│ {scdbFw.InsertOpsPerSec,10:N0} │ {scdbFw.ReadOpsPerSec,8:N0} │ {scdbFw.UpdateOpsPerSec,8:N0} │ {scdbFw.DeleteOpsPerSec,8:N0} ║");
         Console.WriteLine($"║ SQLite        │ {sqlite.InsertOpsPerSec,10:N0} │ {sqlite.ReadOpsPerSec,8:N0} │ {sqlite.UpdateOpsPerSec,8:N0} │ {sqlite.DeleteOpsPerSec,8:N0} ║");
-        Console.WriteLine($"\n  UPDATE gap: {sqlite.UpdateOpsPerSec / (double)scdb.UpdateOpsPerSec:F1}x   DELETE gap: {sqlite.DeleteOpsPerSec / (double)scdb.DeleteOpsPerSec:F1}x");
+        Console.WriteLine($"\n  UPDATE gap: SQLite vs legacy {sqlite.UpdateOpsPerSec / (double)scdb.UpdateOpsPerSec:F1}x   vs fixed-width {sqlite.UpdateOpsPerSec / (double)scdbFw.UpdateOpsPerSec:F1}x");
+        Console.WriteLine($"  DELETE gap: SQLite vs legacy {sqlite.DeleteOpsPerSec / (double)scdb.DeleteOpsPerSec:F1}x   vs fixed-width {sqlite.DeleteOpsPerSec / (double)scdbFw.DeleteOpsPerSec:F1}x");
 
         var results = new Dictionary<string, BenchmarkResult>
         {
-            ["SharpCoreDB (SQL, PK)"] = scdb,
+            ["SharpCoreDB (SQL, PK, legacy)"] = scdb,
+            ["SharpCoreDB (SQL, PK, fixed-width)"] = scdbFw,
             ["SQLite"] = sqlite,
         };
 


### PR DESCRIPTION
## Summary

The fair PK comparison (`--pk`) now also runs SharpCoreDB with the **fixed-width record layout** (`FixedWidthRecordLayout=true`) on the same `id INTEGER PRIMARY KEY` schema, so the layout's effect is measured head-to-head with the legacy variable-length layout and SQLite.

## Measured (AppendOnly, 1 run, this machine)

| DB | INSERT | READ | UPDATE | DELETE |
|---|---:|---:|---:|---:|
| SharpCoreDB legacy | 87K | 63K | 41K | 65K |
| SharpCoreDB **fixed-width** | **128K (+46%)** | 74K | **51K (+23%)** | 75K |
| SQLite | 124K | 89K | 261K | 353K |

- UPDATE gap vs SQLite: **6.3× → 5.1×**
- DELETE gap vs SQLite: **5.4× → 4.7×**

## Interpretation

Fixed-width gives a real, broad win (+46% INSERT, +23% UPDATE, +16-18% READ/DELETE) but does **not** close the residual ~5× UPDATE/DELETE gap on this workload. The same-length `SET score = …` update was already in-place on the legacy layout (0 file growth); the residual cost is the **per-row read-modify-write + index maintenance + resolution path**, not the record encoding. This data informs whether to (a) land fixed-width-by-default for new PK'd columnar tables (worth +23-46%, but changes the default on-disk encoding for new tables) and/or (b) target the per-row cost (managed page cache / batch row reads).
