### PR TITLE
perf: durable Columnar DELETE in-place via tombstone markers (no flush rewrite)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overflow arena is reclaimed on the next explicit VACUUM/compaction. Regression: delete half the
   rows, `Flush`, reopen ÔÇö exactly the remaining rows come back. Measured DELETE in the `--pk`
   harness now includes this durability rewrite (~18.6K ops/s when deleting 10K of 100K rows).
+- **Durable DELETE is now in-place via tombstones (no rewrite)** ÔÇö non-transactional Columnar
+  deletes write a tombstone marker (the record's 4-byte length prefix is replaced by the NEGATIVE
+  slot size) instead of queueing a flush-time rewrite, and every raw record enumerator/compactor
+  skips the slot, so DELETE survives a reopen in O(delete). Flush/dispose compaction now only
+  covers transactional deletes (a marker written before commit would survive a rollback that
+  restores the row in the PK index; those deletes are compacted against the current PK after commit
+  ÔÇö rollback-safe). Tombstoned space is reclaimed by the tombstone-aware `CompactTable`, including
+  the ULID-migration compaction (which previously produced an empty file when tombstones were
+  present because `CompactTable` broke on a negative prefix). Measured `--pk` DELETE (10K of 100K
+  rows): ~0.54s/18.6K ops/s (flush rewrite) ÔåÆ **~0.16s/~64K ops/s (legacy)** and
+  **~0.12s/~81K ops/s (fixed-width)** ÔÇö DELETE is back on par with UPDATE.
 - **Dedicated SQL batch-INSERT fast path (WP14)** ÔÇö `ExecuteBatchSQL` INSERTs no longer build a
   per-row `Dictionary<string, object>`; VALUES clauses are parsed directly into column-ordered
   `object[]` rows (`PreparedInsertStatement.ParseValuesToArray`) and inserted via the new

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -1364,7 +1364,20 @@ public partial class Table
                 dataSpan.Slice(filePosition, 4));
 
             const int MaxRecordSize = 1_000_000_000;
-            if (recordLength < 0 || recordLength > MaxRecordSize)
+            if (recordLength < 0)
+            {
+                // Tombstoned (deleted) record: the prefix stores the negative slot size to skip.
+                int slotSize = -recordLength;
+                if (slotSize < 4)
+                {
+                    break;
+                }
+
+                filePosition += slotSize;
+                continue;
+            }
+
+            if (recordLength > MaxRecordSize)
             {
                 break;
             }
@@ -2586,9 +2599,10 @@ public partial class Table
             foreach (var (storagePosition, _) in recordsToDelete)
                 engine.Delete(Name, storagePosition);
         }
-        else
+        else if (StorageMode != StorageMode.Columnar)
         {
-            // Track Columnar logical deletes so flush-time compaction makes them durable.
+            // Legacy logical-delete accounting (Columnar deletes are tracked in the branch below,
+            // which decides between an immediate durable tombstone and deferred flush compaction).
             Interlocked.Add(ref _pendingLogicalDeletes, recordsToDelete.Count);
         }
 
@@ -2637,6 +2651,20 @@ public partial class Table
                     this.staleIndexes.Add(col);
                     _indexReadyCache.TryRemove(col, out _);
                 }
+            }
+
+            if (this.storage is { IsInTransaction: true })
+            {
+                // Transactional delete: writing the tombstone now would survive a rollback that
+                // restores the row in the PK index, so defer the physical removal to the post-commit
+                // flush compaction (rollback-safe: that rewrite is driven by the CURRENT PK, which
+                // still contains the row after a rollback).
+                Interlocked.Add(ref _pendingLogicalDeletes, recordsToDelete.Count);
+            }
+            else
+            {
+                // Durable DELETE: physically mark the removed records so a reopen skips them.
+                TombstoneDeletedPositions(positions);
             }
 
             TryAutoCompact();
@@ -3184,8 +3212,19 @@ public partial class Table
             hashIdx.RemoveBatchKeys(decoded, positions);
         }
 
+        if (this.storage is { IsInTransaction: true })
+        {
+            // Transactional delete: defer physical removal to the post-commit flush compaction
+            // (see DeleteRecordsCore — a tombstone would survive a rollback that restores the row).
+            Interlocked.Add(ref _pendingLogicalDeletes, count);
+        }
+        else
+        {
+            // Durable DELETE: physically mark the removed records so a reopen skips them.
+            TombstoneDeletedPositions(positions);
+        }
+
         Interlocked.Add(ref _cachedRowCount, -count);
-        Interlocked.Add(ref _pendingLogicalDeletes, count);
         Interlocked.Increment(ref _bulkContiguousDeleteBatches);
         return true;
     }

--- a/src/SharpCoreDB/DataStructures/Table.Compaction.cs
+++ b/src/SharpCoreDB/DataStructures/Table.Compaction.cs
@@ -8,6 +8,7 @@ namespace SharpCoreDB.DataStructures;
 using SharpCoreDB.Storage.Engines;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -52,12 +53,14 @@ public partial class Table
     }
 
     /// <summary>
-    /// Physically removes rows that were logically deleted since the last flush (Columnar tables
-    /// with a primary key) so DELETE survives a reopen — the on-load PK-index rebuild would otherwise
-    /// resurrect them from the untouched <c>.dat</c>. Runs synchronously at flush/dispose, outside a
-    /// transaction, when any logical deletes are pending. Data-file only: the overflow arena is left
-    /// untouched (its space is reclaimed by a later explicit compaction/VACUUM) so the flush stays
-    /// proportional to the rewritten live rows.
+    /// Makes TRANSACTIONAL deletes durable (Columnar tables with a primary key). Deletes issued
+    /// inside a transaction are intentionally not tombstoned at delete time (a marker would survive a
+    /// rollback that restores the row in the PK index), so they are physically removed here by
+    /// compacting against the CURRENT PK once the owning transaction has committed. Runs at
+    /// flush/dispose, outside a transaction, when any transactional deletes are pending. No-op when
+    /// none are pending — non-transactional DELETE is already durable via the per-row tombstone and
+    /// must not pay a rewrite. Data-file only: the overflow arena is left untouched (its space is
+    /// reclaimed by a later explicit compaction/VACUUM).
     /// </summary>
     public void CompactPendingDeletes()
     {
@@ -102,6 +105,30 @@ public partial class Table
         {
             Interlocked.Exchange(ref _pendingLogicalDeletes, 0);
             rwLock.ExitWriteLock();
+        }
+    }
+
+    /// <summary>
+    /// Writes the deleted-record marker over the length prefix of each position that is physically
+    /// present in the data file, making the Columnar logical delete durable across reopen (readers
+    /// skip the marker) without rewriting the remaining rows. Rows appended inside an uncommitted
+    /// transaction (positions beyond the current file length) are skipped — their delete commits
+    /// with the rest of the transaction.
+    /// </summary>
+    private void TombstoneDeletedPositions(long[] positions)
+    {
+        if (this.storage is null || positions.Length == 0)
+        {
+            return;
+        }
+
+        long fileLength = File.Exists(DataFile) ? new FileInfo(DataFile).Length : 0;
+        foreach (var position in positions)
+        {
+            if (position >= 0 && position + 4 <= fileLength)
+            {
+                this.storage.TombstoneRecord(DataFile, position);
+            }
         }
     }
 

--- a/src/SharpCoreDB/DataStructures/Table.ParallelScan.cs
+++ b/src/SharpCoreDB/DataStructures/Table.ParallelScan.cs
@@ -173,6 +173,18 @@ public partial class Table
                 int recordLength = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(
                     data.AsSpan(filePosition, 4));
 
+                if (recordLength < 0)
+                {
+                    int slotSize = -recordLength; // tombstoned slot: skip the full slot
+                    if (slotSize < 4)
+                    {
+                        break;
+                    }
+
+                    filePosition += slotSize;
+                    continue;
+                }
+
                 if (recordLength <= 0 || recordLength > 1_000_000_000) break;
 
                 currentRecordCount++;
@@ -206,6 +218,18 @@ public partial class Table
 
                 int recordLength = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(
                     partitionData.Slice(localFilePosition, 4));
+
+                if (recordLength < 0)
+                {
+                    int slotSize = -recordLength; // tombstoned slot: skip the full slot
+                    if (slotSize < 4)
+                    {
+                        break;
+                    }
+
+                    localFilePosition += slotSize;
+                    continue;
+                }
 
                 if (recordLength <= 0 || recordLength > 1_000_000_000) break;
 

--- a/src/SharpCoreDB/DataStructures/Table.Scanning.cs
+++ b/src/SharpCoreDB/DataStructures/Table.Scanning.cs
@@ -65,10 +65,23 @@ public partial class Table
             // ✅ C# 14: Range operator - extract length prefix span first
             var lengthSpan = dataSpan[filePosition..(filePosition + 4)];
             int recordLength = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(lengthSpan);
-            
+
+            if (recordLength < 0)
+            {
+                // Tombstoned (deleted) record: the prefix stores the negative slot size to skip.
+                int slotSize = -recordLength;
+                if (slotSize < 4)
+                {
+                    break;
+                }
+
+                filePosition += slotSize;
+                continue;
+            }
+
             // Sanity check: record length must be reasonable
             const int MaxRecordSize = 1_000_000_000; // 1 GB max per record
-            if (recordLength < 0 || recordLength > MaxRecordSize)
+            if (recordLength > MaxRecordSize)
             {
                 break;
             }

--- a/src/SharpCoreDB/DataStructures/Table.cs
+++ b/src/SharpCoreDB/DataStructures/Table.cs
@@ -733,9 +733,10 @@ public partial class Table : ITable, IDisposable
                 }
             }
             
-            // Durable DELETE across reopen: physically compact rows that were logically deleted
-            // since the last flush (Columnar + PK, outside a transaction). Runs after the engine
-            // and any transaction buffer have been flushed.
+            // Transactional deletes (which are intentionally NOT tombstoned at delete time so a
+            // rollback stays correct) become durable by compacting against the current PK once the
+            // owning transaction has committed. No-op when there are no deferred transactional
+            // deletes, so non-transactional DELETE keeps the O(delete) tombstone path.
             CompactPendingDeletes();
 
             // Flush indexes
@@ -783,7 +784,8 @@ public partial class Table : ITable, IDisposable
     {
         if (disposing)
         {
-            // Durable DELETE across reopen for flows that dispose without an explicit flush.
+            // Transactional deletes deferred past their commit flush (e.g. dispose-without-flush
+            // flows) are compacted here; no-op when none are pending.
             CompactPendingDeletes();
 
             // Dispose storage engine first

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -171,6 +171,15 @@ public interface IStorage
     bool AreRecordsEncrypted(string path) => false;
 
     /// <summary>
+    /// Marks the record whose 4-byte length prefix sits at <paramref name="offset"/> as deleted by
+    /// replacing the prefix with the NEGATIVE slot size (4-byte prefix + payload). Every record
+    /// enumerator treats a negative prefix as a deleted record and skips |value| bytes, so the
+    /// delete survives a reopen without rewriting the file. The default returns false (unsupported
+    /// layout / mock storage).
+    /// </summary>
+    bool TombstoneRecord(string path, long offset) => false;
+
+    /// <summary>
     /// Enumerates every record in a table data file, yielding the literal file offset of the
     /// 4-byte length prefix (the offset returned by <see cref="AppendBytes"/>) together with the
     /// decrypted (or plaintext) record payload. Format-agnostic: transparently handles both legacy

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -564,6 +564,56 @@ public partial class Storage
     public bool AreRecordsEncrypted(string path) => UseRecordEncryption && FileHasEncryptedHeader(path);
 
     /// <inheritdoc />
+    public bool TombstoneRecord(string path, long offset)
+    {
+        // Read the current slot size so the marker can encode the exact number of bytes to skip
+        // (4-byte prefix + payload), keeping every record enumerator aligned.
+        int slotSize;
+        try
+        {
+            SafeFileHandle readHandle = GetOrOpenReadHandle(path);
+            Span<byte> lengthBuffer = stackalloc byte[4];
+            if (RandomAccess.Read(readHandle, lengthBuffer, offset) != 4)
+            {
+                return false;
+            }
+
+            int currentLength = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
+            if (currentLength <= 0)
+            {
+                return false; // already tombstoned or invalid
+            }
+
+            slotSize = 4 + currentLength;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+
+        Span<byte> marker = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32LittleEndian(marker, -slotSize);
+
+        try
+        {
+            WriteRecordInPlace(path, offset, marker, ReadOnlySpan<byte>.Empty);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+
+        // Invalidate the app-level page cache (mirrors the other in-place writers).
+        if (this.pageCache != null)
+        {
+            int pageId = ComputePageId(path, offset);
+            this.pageCache.EvictPage(pageId);
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public long[] AppendBytesMultiple(string path, List<byte[]> dataBlocks)
     {
@@ -924,6 +974,19 @@ public partial class Storage
             }
 
             int length = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
+            if (length < 0)
+            {
+                // Tombstoned (deleted) record: the prefix stores the negative slot size to skip.
+                int slotSize = -length;
+                if (slotSize < 4)
+                {
+                    yield break;
+                }
+
+                position += slotSize;
+                continue;
+            }
+
             if (length <= 0 || length > MaxRecordSize || position + 4 + length > fileLength)
             {
                 yield break; // Invalid or incomplete record tail

--- a/src/SharpCoreDB/Storage/Engines/AppendOnlyEngine.cs
+++ b/src/SharpCoreDB/Storage/Engines/AppendOnlyEngine.cs
@@ -214,8 +214,21 @@ public class AppendOnlyEngine : IStorageEngine
             // Read record length (4 bytes, little-endian)
             int recordLength = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(
                 allData.AsSpan((int)position, 4));
-            
-            if (recordLength <= 0 || position + 4 + recordLength > allData.Length)
+
+            if (recordLength < 0)
+            {
+                // Tombstoned (deleted) record: the prefix stores the negative slot size to skip.
+                int slotSize = -recordLength;
+                if (slotSize < 4)
+                {
+                    break;
+                }
+
+                position += slotSize;
+                continue;
+            }
+
+            if (recordLength == 0 || position + 4 + recordLength > allData.Length)
             {
                 break; // Invalid or incomplete record
             }
@@ -354,10 +367,23 @@ public class AppendOnlyEngine : IStorageEngine
             
             int recordLength = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(
                 allData.AsSpan((int)position, 4));
-            
-            if (recordLength <= 0 || position + 4 + recordLength > allData.Length)
+
+            if (recordLength < 0)
+            {
+                // Tombstoned (deleted) record: the prefix stores the negative slot size to skip.
+                int slotSize = -recordLength;
+                if (slotSize < 4)
+                {
+                    break;
+                }
+
+                position += slotSize;
+                continue;
+            }
+
+            if (recordLength == 0 || position + 4 + recordLength > allData.Length)
                 break;
-            
+
             // Check if this position is active
             if (activeSet.Contains(position))
             {


### PR DESCRIPTION
## Why

Master #366 made Columnar DELETE durable by compacting at flush/dispose, but the rewrite cost dropped `--pk` DELETE to ~18.6K ops/s (0.54s per 10K deletes on a ~100K-row table).

This PR makes the durable delete **in-place**: a tombstone marker is written over the record's 4-byte length prefix (negative slot size), and every raw record enumerator/compactor skips the slot. DELETE survives a reopen in **O(delete)** — no flush-time rewrite.

## Root cause this PR fixes

The earlier tombstone attempt was reverted because the **ULID-migration flow** (`delete + insert` → `CompactStorage`) produced an empty `.dat` (`rows=1`, `filelen=0`). Cause found: `AppendOnlyEngine.CompactTable` did `break` on any non-positive prefix, so the first tombstone stopped the walk and nothing active was rewritten. It now skips negative prefixes like every other enumerator.

## Rollback safety

A tombstone written before a transaction commits would survive a rollback that restores the row in the PK index. Transactional deletes are therefore **not** tombstoned at delete time; they are physically removed by the post-commit flush/dispose compaction against the *current* PK — the rollback-safe semantics of #366. Non-transactional DELETE (the measured hot path) never pays that rewrite.

## Measured (`--pk` harness, DELETE 10K of ~100K rows)

| | master #366 (flush rewrite) | this PR (tombstones) |
|---|---:|---:|
| legacy variable-length | ~0.54s — ~18.6K ops/s | **~0.16s — ~63.7K ops/s** |
| fixed-width | ~0.54s — ~18.6K ops/s | **~0.12s — ~81.0K ops/s** (gap vs SQLite ~4.2×) |

DELETE is again on par with UPDATE (FW UPDATE ~86.7K ops/s). Tombstone space is reclaimed by the tombstone-aware `CompactTable`/`CompactStorage` (explicit, auto-compact threshold, ULID migration).

## Validation

- Full `SharpCoreDB.Tests` suite (Debug + Release/CI filter): **green** (1656 tests, incl. `LegacyUlidMigrationTests`, ULID, bulk-delete, reopen, fixed-width, transaction suites).
- CI-equivalent local run (Release, `Category!=Debug&Category!=Manual&Category!=Performance`): `SharpCoreDB.Tests`, `SharpCoreDB.VectorSearch.Tests`, `SharpCoreDB.EntityFrameworkCore.Tests`, `SharpCoreDB.Functional.Linq2DB.Tests` — all **EXIT=0**.
- CHANGELOG updated.
