### PR TITLE
perf: key-only DELETE row decode (B1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,17 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overflow arena is reclaimed on the next explicit VACUUM/compaction. Regression: delete half the
   rows, `Flush`, reopen ÔÇö exactly the remaining rows come back. Measured DELETE in the `--pk`
   harness now includes this durability rewrite (~18.6K ops/s when deleting 10K of 100K rows).
-- **Durable DELETE is now in-place via tombstones (no rewrite)** ÔÇö non-transactional Columnar
-  deletes write a tombstone marker (the record's 4-byte length prefix is replaced by the NEGATIVE
-  slot size) instead of queueing a flush-time rewrite, and every raw record enumerator/compactor
-  skips the slot, so DELETE survives a reopen in O(delete). Flush/dispose compaction now only
-  covers transactional deletes (a marker written before commit would survive a rollback that
-  restores the row in the PK index; those deletes are compacted against the current PK after commit
-  ÔÇö rollback-safe). Tombstoned space is reclaimed by the tombstone-aware `CompactTable`, including
-  the ULID-migration compaction (which previously produced an empty file when tombstones were
-  present because `CompactTable` broke on a negative prefix). Measured `--pk` DELETE (10K of 100K
-  rows): ~0.54s/18.6K ops/s (flush rewrite) ÔåÆ **~0.16s/~64K ops/s (legacy)** and
-  **~0.12s/~81K ops/s (fixed-width)** ÔÇö DELETE is back on par with UPDATE.
+- **Durable DELETE is now in-place via tombstones (no rewrite)** ÔÇö Columnar deletes write a
+  tombstone marker (the record's 4-byte length prefix is replaced by the NEGATIVE slot size)
+  instead of queueing a flush-time rewrite, and every raw record enumerator/compactor skips the
+  slot, so DELETE survives a reopen in O(delete). Non-transactional deletes write the marker at
+  delete time; transactional deletes (e.g. any `ExecuteBatchSQL` batch, which runs inside a storage
+  transaction) buffer the offsets and apply the markers at COMMIT ÔÇö rollback discards the buffer,
+  so a rolled-back delete keeps its row, and the flush-time full-file rewrite (`CompactPendingDeletes`)
+  is no longer on the batch-DELETE path. Tombstoned space is reclaimed by the tombstone-aware
+  `CompactTable`, including the ULID-migration compaction (which previously produced an empty file
+  when tombstones were present because `CompactTable` broke on a negative prefix). Measured `--pk`
+  DELETE (10K of 100K rows): ~0.54s/18.6K ops/s (flush rewrite) ÔåÆ **~0.16s/~64K ops/s (legacy)** and
+  **~0.13s/~78K ops/s (fixed-width)**; comparative-harness DELETE (docs table): SQL ~0.82s/~12K ÔåÆ
+  **~0.24s/~41K ops/s**, Direct ~0.63s/~16K ÔåÆ **~0.17s/~58K ops/s** ÔÇö DELETE is back on par with UPDATE.
 - **Dedicated SQL batch-INSERT fast path (WP14)** ÔÇö `ExecuteBatchSQL` INSERTs no longer build a
   per-row `Dictionary<string, object>`; VALUES clauses are parsed directly into column-ordered
   `object[]` rows (`PreparedInsertStatement.ParseValuesToArray`) and inserted via the new

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -3059,6 +3059,9 @@ public partial class Table
                 }
             }
 
+            // B1: decode only the columns the delete core touches (PK + loaded hash-index columns).
+            int[] deleteKeyColumns = BuildDeleteKeyColumns();
+
             var recordsToDelete = new List<(long storagePosition, Dictionary<string, object> row)>();
 
             foreach (var (col, literal) in conditions)
@@ -3076,7 +3079,7 @@ public partial class Table
                         var fastData = engine.Read(Name, fastSearch.Value);
                         if (fastData != null)
                         {
-                            var fastRow = DeserializeRowFromSpan(fastData);
+                            var fastRow = DeserializeDeleteKeyRow(fastData, deleteKeyColumns) ?? DeserializeRowFromSpan(fastData);
                             if (fastRow != null)
                             {
                                 recordsToDelete.Add((fastSearch.Value, fastRow));
@@ -3103,7 +3106,7 @@ public partial class Table
                                     var data = engine.Read(Name, pos);
                                     if (data != null)
                                     {
-                                        var row = DeserializeRowFromSpan(data);
+                                        var row = DeserializeDeleteKeyRow(data, deleteKeyColumns) ?? DeserializeRowFromSpan(data);
                                         if (row != null) recordsToDelete.Add((pos, row));
                                     }
                                 }
@@ -3173,6 +3176,78 @@ public partial class Table
     private static string UnquoteSqlLiteral(string raw)
     {
         return raw.AsSpan().Trim().Trim("'\"".AsSpan()).ToString();
+    }
+
+    /// <summary>
+    /// B1: column indexes a delete target actually needs — the PK value (B-tree cleanup) plus every
+    /// loaded hash-index column (key-only hash cleanup). Ascending, de-duplicated.
+    /// </summary>
+    private int[] BuildDeleteKeyColumns()
+    {
+        var list = new List<int>(4);
+        if (this.PrimaryKeyIndex >= 0)
+        {
+            list.Add(this.PrimaryKeyIndex);
+        }
+
+        foreach (var kvp in this.hashIndexes)
+        {
+            int colIdx = this.Columns.IndexOf(kvp.Key);
+            if (colIdx >= 0 && !list.Contains(colIdx))
+            {
+                list.Add(colIdx);
+            }
+        }
+
+        list.Sort();
+        return list.ToArray();
+    }
+
+    /// <summary>
+    /// B1: decodes only the columns listed in <paramref name="wanted"/> (ascending) from a legacy
+    /// variable-length serialized row, skipping the unneeded columns' payload parsing entirely.
+    /// Returns a minimal dictionary (pk + hash-index columns only) so <see cref="DeleteRecordsCore"/>
+    /// performs the identical PK/hash lookups without materializing the full row. Returns null for
+    /// fixed-width layouts (those go through the fixed-width codec) or corrupt rows — callers fall
+    /// back to full-row deserialization in that case.
+    /// </summary>
+    private Dictionary<string, object>? DeserializeDeleteKeyRow(byte[] data, int[] wanted)
+    {
+        if (_fixedWidthRecords || data == null || data.Length == 0 || wanted.Length == 0)
+        {
+            return null;
+        }
+
+        ReadOnlySpan<byte> span = data.AsSpan();
+        int offset = 0;
+        Dictionary<string, object>? row = null;
+        int wi = 0;
+
+        for (int i = 0; i < Columns.Count; i++)
+        {
+            if (offset >= span.Length)
+            {
+                return null;
+            }
+
+            int size = ReadColumnEncodedSize(span, offset, ColumnTypes[i]);
+            if (size <= 0 || offset + size > span.Length)
+            {
+                return null; // corrupt / unexpected layout → full-row fallback
+            }
+
+            if (wi < wanted.Length && wanted[wi] == i)
+            {
+                var value = ReadTypedValueFromSpan(span.Slice(offset), ColumnTypes[i], out _);
+                row ??= new Dictionary<string, object>(wanted.Length);
+                row[Columns[i]] = value;
+                wi++;
+            }
+
+            offset += size;
+        }
+
+        return row;
     }
 
     /// <summary>

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -3022,6 +3022,160 @@ public partial class Table
     }
 
     /// <summary>
+    /// Structured variant of <see cref="DeleteMultiple"/> used by the SQL batch dispatcher for
+    /// canonical single-row DELETE statements (`DELETE FROM t WHERE col = literal`, as detected by
+    /// the canonical-DML scanner). The WHERE column and raw literal are already known, so the
+    /// per-statement `col = literal` string rebuild and the second <see cref="TryParseSimpleWhereClause"/>
+    /// pass are skipped on the hot path. Semantics mirror <see cref="DeleteMultiple"/> exactly
+    /// (PK fast path → hash-index fast path → generic fallback with a lazily rebuilt WHERE string,
+    /// only reached for unusual shapes).
+    /// </summary>
+    /// <param name="conditions">Column name and RAW literal value (quotes as written in SQL).</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    internal void DeleteMultipleKeys(List<(string Column, string Literal)> conditions)
+    {
+        if (this.isReadOnly) throw new InvalidOperationException(ReadOnlyDeleteError);
+        if (conditions.Count == 0) return;
+
+        this.rwLock.EnterWriteLock();
+        try
+        {
+            var engine = GetOrCreateStorageEngine();
+            EnsureAllRegisteredIndexesLoaded();
+
+            // B9 single-pass contiguous DELETE consumes WHERE strings; attempt it (without touching
+            // anything) only when every condition is a literal on the PK column, like the caller.
+            if (this.PrimaryKeyIndex >= 0 && AllPkLiteralConditions(conditions))
+            {
+                var wheres = new List<string>(conditions.Count);
+                foreach (var (col, literal) in conditions)
+                {
+                    wheres.Add(col + " = " + literal);
+                }
+
+                if (TryBulkDeleteContiguousFixedWidth(wheres))
+                {
+                    return;
+                }
+            }
+
+            var recordsToDelete = new List<(long storagePosition, Dictionary<string, object> row)>();
+
+            foreach (var (col, literal) in conditions)
+            {
+                string value = UnquoteSqlLiteral(literal);
+
+                // Issue #7 PK fast path (structured: no WHERE-string re-parse).
+                if (StorageMode != StorageMode.PageBased &&
+                    this.PrimaryKeyIndex >= 0 &&
+                    string.Equals(col, this.Columns[this.PrimaryKeyIndex], StringComparison.OrdinalIgnoreCase))
+                {
+                    var fastSearch = this.Index.Search(value);
+                    if (fastSearch.Found)
+                    {
+                        var fastData = engine.Read(Name, fastSearch.Value);
+                        if (fastData != null)
+                        {
+                            var fastRow = DeserializeRowFromSpan(fastData);
+                            if (fastRow != null)
+                            {
+                                recordsToDelete.Add((fastSearch.Value, fastRow));
+                            }
+                        }
+
+                        continue;
+                    }
+                }
+                // Hash index fast path.
+                if (this.registeredIndexes.ContainsKey(col))
+                {
+                    EnsureIndexLoaded(col);
+                    if (this.hashIndexes.TryGetValue(col, out var hashIndex))
+                    {
+                        var colIdx = this.Columns.IndexOf(col);
+                        if (colIdx >= 0)
+                        {
+                            var key = ParseValueForHashLookup(value, this.ColumnTypes[colIdx]);
+                            if (key != null)
+                            {
+                                foreach (var pos in hashIndex.LookupPositionsUnsafe(key))
+                                {
+                                    var data = engine.Read(Name, pos);
+                                    if (data != null)
+                                    {
+                                        var row = DeserializeRowFromSpan(data);
+                                        if (row != null) recordsToDelete.Add((pos, row));
+                                    }
+                                }
+
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                // Generic fallback (rare for canonical shapes): rebuild the WHERE string exactly as
+                // the caller would have and mirror DeleteMultiple.
+                string where = col + " = " + literal;
+                if (this.PrimaryKeyIndex >= 0)
+                {
+                    var rows = SelectInternal(where, orderBy: null, asc: true, noEncrypt: false);
+                    var pkCol = this.Columns[this.PrimaryKeyIndex];
+                    foreach (var row in rows)
+                    {
+                        if (row.TryGetValue(pkCol, out var pkValue) && pkValue != null)
+                        {
+                            var searchResult = this.Index.Search(pkValue.ToString() ?? string.Empty);
+                            if (searchResult.Found)
+                                recordsToDelete.Add((searchResult.Value, row));
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var (storageRef, data) in engine.GetAllRecords(Name))
+                    {
+                        var row = DeserializeRowFromSpan(data);
+                        if (row != null && (string.IsNullOrEmpty(where) || EvaluateSimpleWhere(row, where)))
+                            recordsToDelete.Add((storageRef, row));
+                    }
+                }
+            }
+
+            if (recordsToDelete.Count == 0) return;
+
+            DeleteRecordsCore(recordsToDelete);
+        }
+        finally
+        {
+            this.rwLock.ExitWriteLock();
+        }
+    }
+
+    private bool AllPkLiteralConditions(List<(string Column, string Literal)> conditions)
+    {
+        var pkCol = this.Columns[this.PrimaryKeyIndex];
+        foreach (var (col, _) in conditions)
+        {
+            if (!string.Equals(col, pkCol, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Mirrors the value normalization of <see cref="TryParseSimpleWhereClause"/> (trim whitespace,
+    /// then trim enclosing <c>'</c>/<c>"</c> quotes) on a raw SQL literal.
+    /// </summary>
+    private static string UnquoteSqlLiteral(string raw)
+    {
+        return raw.AsSpan().Trim().Trim("'\"".AsSpan()).ToString();
+    }
+
+    /// <summary>
     /// Shared B8/B9 probe: resolves each key's record position through the PK B-tree, requires the
     /// positions to be physically adjacent at the fixed-width stride, reads the whole contiguous
     /// span through the storage layer's cached handle and verifies every 4-byte length prefix.

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -2655,11 +2655,16 @@ public partial class Table
 
             if (this.storage is { IsInTransaction: true })
             {
-                // Transactional delete: writing the tombstone now would survive a rollback that
-                // restores the row in the PK index, so defer the physical removal to the post-commit
-                // flush compaction (rollback-safe: that rewrite is driven by the CURRENT PK, which
-                // still contains the row after a rollback).
-                Interlocked.Add(ref _pendingLogicalDeletes, recordsToDelete.Count);
+                // Transactional delete: buffer the physical offsets so the in-place marker is
+                // applied at COMMIT (rollback discards the buffer). Durable in O(delete) — the
+                // flush-time full-file rewrite is no longer needed for transactional deletes.
+                foreach (var position in positions)
+                {
+                    if (position >= 0)
+                    {
+                        this.storage.BufferTombstoneForCommit(DataFile, position);
+                    }
+                }
             }
             else
             {
@@ -3214,9 +3219,15 @@ public partial class Table
 
         if (this.storage is { IsInTransaction: true })
         {
-            // Transactional delete: defer physical removal to the post-commit flush compaction
-            // (see DeleteRecordsCore — a tombstone would survive a rollback that restores the row).
-            Interlocked.Add(ref _pendingLogicalDeletes, count);
+            // Transactional delete: buffer the physical offsets so the in-place marker is applied
+            // at COMMIT (see DeleteRecordsCore — rollback discards the buffer).
+            foreach (var position in positions)
+            {
+                if (position >= 0)
+                {
+                    this.storage.BufferTombstoneForCommit(DataFile, position);
+                }
+            }
         }
         else
         {

--- a/src/SharpCoreDB/DataStructures/Table.Compaction.cs
+++ b/src/SharpCoreDB/DataStructures/Table.Compaction.cs
@@ -8,7 +8,6 @@ namespace SharpCoreDB.DataStructures;
 using SharpCoreDB.Storage.Engines;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -113,7 +112,8 @@ public partial class Table
     /// present in the data file, making the Columnar logical delete durable across reopen (readers
     /// skip the marker) without rewriting the remaining rows. Rows appended inside an uncommitted
     /// transaction (positions beyond the current file length) are skipped — their delete commits
-    /// with the rest of the transaction.
+    /// with the rest of the transaction. The storage layer batches the in-place marker writes and
+    /// de-duplicates page-cache evictions per page.
     /// </summary>
     private void TombstoneDeletedPositions(long[] positions)
     {
@@ -122,14 +122,7 @@ public partial class Table
             return;
         }
 
-        long fileLength = File.Exists(DataFile) ? new FileInfo(DataFile).Length : 0;
-        foreach (var position in positions)
-        {
-            if (position >= 0 && position + 4 <= fileLength)
-            {
-                this.storage.TombstoneRecord(DataFile, position);
-            }
-        }
+        this.storage.TombstoneRecords(DataFile, positions);
     }
 
     /// <summary>

--- a/src/SharpCoreDB/Database/Execution/Database.Batch.cs
+++ b/src/SharpCoreDB/Database/Execution/Database.Batch.cs
@@ -923,10 +923,12 @@ public partial class Database
     /// <param name="tableName">The parsed table name.</param>
     /// <param name="where">The parsed WHERE clause.</param>
     /// <returns>True if the statement was successfully parsed as a DELETE.</returns>
-    private bool TryParseDeleteForBatch(string sql, out string tableName, out string where)
+    private bool TryParseDeleteForBatch(string sql, out string tableName, out string where, out string? whereColumn, out string? whereLiteral)
     {
         tableName = string.Empty;
         where = string.Empty;
+        whereColumn = null;
+        whereLiteral = null;
 
         // Phase-2 fast path: canonical single-row shape
         // `DELETE FROM <table> WHERE <col> = <literal>` — regex-free.
@@ -938,7 +940,10 @@ public partial class Database
             }
 
             tableName = fastTable;
-            where = whereCol + " = " + whereValRaw;
+            whereColumn = whereCol;
+            whereLiteral = whereValRaw;
+            // Where stays empty for canonical statements — the table layer reconstructs it only
+            // when a fallback actually needs it (B3: no per-statement string allocation).
             return true;
         }
 
@@ -997,7 +1002,9 @@ public partial class Database
 
         // ✅ PERF: Group UPDATE/DELETE by table for single-lock batch execution
         Dictionary<string, List<(string where, Dictionary<string, object> updates)>> updatesByTable = [];
-        Dictionary<string, List<string>> deletesByTable = [];
+        // Canonical DELETE statements carry the pre-parsed column + raw literal so the table layer
+        // can skip the per-statement WHERE rebuild/re-parse (B3); Where stays empty for those.
+        Dictionary<string, List<(string Where, string? Column, string? Literal)>> deletesByTable = [];
 
         foreach (var sql in statements)
         {
@@ -1031,14 +1038,14 @@ public partial class Database
                 }
                 updList.Add((updWhere, updSets));
             }
-            else if (TryParseDeleteForBatch(sql, out var delTableName, out var delWhere))
+            else if (TryParseDeleteForBatch(sql, out var delTableName, out var delWhere, out var delCol, out var delLiteral))
             {
                 if (!deletesByTable.TryGetValue(delTableName, out var delList))
                 {
                     delList = [];
                     deletesByTable[delTableName] = delList;
                 }
-                delList.Add(delWhere);
+                delList.Add((delWhere, delCol, delLiteral));
             }
             else
             {
@@ -1097,11 +1104,42 @@ public partial class Database
                 }
 
                 // ✅ PERF: Batch DELETE — single lock per table instead of per-statement
-                foreach (var (tableName, wheres) in deletesByTable)
+                foreach (var (tableName, deletes) in deletesByTable)
                 {
                     if (tables.TryGetValue(tableName, out var tbl) && tbl is DataStructures.Table concreteDelete)
                     {
-                        concreteDelete.DeleteMultiple(wheres);
+                        // Canonical batches go through the structured path (no WHERE rebuild/re-parse);
+                        // any non-canonical statement forces the string form for the whole table.
+                        bool allCanonical = true;
+                        foreach (var (_, column, _) in deletes)
+                        {
+                            if (column is null)
+                            {
+                                allCanonical = false;
+                                break;
+                            }
+                        }
+
+                        if (allCanonical)
+                        {
+                            var keys = new List<(string Column, string Literal)>(deletes.Count);
+                            foreach (var (_, column, literal) in deletes)
+                            {
+                                keys.Add((column!, literal!));
+                            }
+
+                            concreteDelete.DeleteMultipleKeys(keys);
+                        }
+                        else
+                        {
+                            var wheres = new List<string>(deletes.Count);
+                            foreach (var (where, column, literal) in deletes)
+                            {
+                                wheres.Add(where.Length > 0 ? where : column + " = " + literal);
+                            }
+
+                            concreteDelete.DeleteMultiple(wheres);
+                        }
                     }
                 }
 

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -180,6 +180,16 @@ public interface IStorage
     bool TombstoneRecord(string path, long offset) => false;
 
     /// <summary>
+    /// Registers a record position to be tombstoned when the CURRENT transaction commits. Deletes
+    /// issued inside a transaction must not write the marker at delete time (it would survive a
+    /// rollback that restores the row), so callers buffer the physical offset here and the storage
+    /// layer applies the in-place marker once the owning transaction commits — durable in O(delete)
+    /// without the flush-time full-file rewrite. On rollback the buffered offsets are discarded.
+    /// The default is a no-op (unsupported layout / mock storage).
+    /// </summary>
+    void BufferTombstoneForCommit(string path, long offset) { }
+
+    /// <summary>
     /// Enumerates every record in a table data file, yielding the literal file offset of the
     /// 4-byte length prefix (the offset returned by <see cref="AppendBytes"/>) together with the
     /// decrypted (or plaintext) record payload. Format-agnostic: transparently handles both legacy

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -190,6 +190,25 @@ public interface IStorage
     void BufferTombstoneForCommit(string path, long offset) { }
 
     /// <summary>
+    /// Bulk <see cref="TombstoneRecord"/>: marks every listed record offset as deleted. The default
+    /// implementation applies <see cref="TombstoneRecord"/> per offset (for alternative/mock
+    /// <see cref="IStorage"/> implementations); the real storage backend batches the in-place
+    /// marker writes and de-duplicates page-cache evictions per page.
+    /// </summary>
+    void TombstoneRecords(string path, long[] offsets)
+    {
+        if (offsets is null)
+        {
+            return;
+        }
+
+        foreach (var offset in offsets)
+        {
+            TombstoneRecord(path, offset);
+        }
+    }
+
+    /// <summary>
     /// Enumerates every record in a table data file, yielding the literal file offset of the
     /// 4-byte length prefix (the offset returned by <see cref="AppendBytes"/>) together with the
     /// decrypted (or plaintext) record payload. Format-agnostic: transparently handles both legacy

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -609,22 +609,7 @@ public partial class Storage
                 continue;
             }
 
-            try
-            {
-                long fileLength = File.Exists(path) ? new FileInfo(path).Length : 0;
-                foreach (var offset in offsets)
-                {
-                    if (offset >= 0 && offset + 4 <= fileLength)
-                    {
-                        TombstoneRecord(path, offset);
-                    }
-                }
-            }
-            catch (IOException)
-            {
-                // Best-effort: a failed marker leaves the row physical; the auto/explicit
-                // compaction reclaims it later.
-            }
+            TombstoneRecords(path, offsets.ToArray());
         }
 
         bufferedTombstones.Clear();
@@ -678,6 +663,60 @@ public partial class Storage
         }
 
         return true;
+    }
+
+    /// <inheritdoc />
+    public void TombstoneRecords(string path, long[] offsets)
+    {
+        if (offsets == null || offsets.Length == 0)
+        {
+            return;
+        }
+
+        HashSet<int>? pagesToEvict = this.pageCache != null ? new HashSet<int>() : null;
+
+        try
+        {
+            SafeFileHandle readHandle = GetOrOpenReadHandle(path);
+            Span<byte> lengthBuffer = stackalloc byte[4];
+            Span<byte> marker = stackalloc byte[4];
+
+            foreach (var offset in offsets)
+            {
+                if (offset < 0)
+                {
+                    continue;
+                }
+
+                if (RandomAccess.Read(readHandle, lengthBuffer, offset) != 4)
+                {
+                    continue; // offset at/beyond EOF — not a physical record
+                }
+
+                int currentLength = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
+                if (currentLength <= 0)
+                {
+                    continue; // already tombstoned or invalid
+                }
+
+                BinaryPrimitives.WriteInt32LittleEndian(marker, -(4 + currentLength));
+                WriteRecordInPlace(path, offset, marker, ReadOnlySpan<byte>.Empty);
+
+                pagesToEvict?.Add(ComputePageId(path, offset));
+            }
+        }
+        catch (IOException)
+        {
+            return;
+        }
+
+        if (pagesToEvict != null)
+        {
+            foreach (var pageId in pagesToEvict)
+            {
+                this.pageCache!.EvictPage(pageId);
+            }
+        }
     }
 
     /// <inheritdoc />

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -49,6 +49,12 @@ public partial class Storage
     // append because OverwriteRecordAt refused to write inside a transaction.
     private readonly ConcurrentDictionary<string, Dictionary<long, byte[]>> bufferedOverwrites = new(StringComparer.Ordinal);
 
+    // ✅ Commit-time tombstones: physical offsets of records deleted inside the current
+    // transaction. The marker is NOT written at delete time (a rollback must keep the row);
+    // ApplyBufferedTombstones writes the in-place negative-prefix markers when the transaction
+    // commits, after the buffered appends are on disk. Rollback discards the buffer.
+    private readonly Dictionary<string, List<long>> bufferedTombstones = new(StringComparer.Ordinal);
+
     // Base file length captured at the first buffered operation of the transaction. In-place
     // overwrites are only safe below this boundary (records already flushed to disk); offsets
     // at or above it belong to still-buffered appends and must fall back to append.
@@ -564,6 +570,67 @@ public partial class Storage
     public bool AreRecordsEncrypted(string path) => UseRecordEncryption && FileHasEncryptedHeader(path);
 
     /// <inheritdoc />
+    public void BufferTombstoneForCommit(string path, long offset)
+    {
+        if (offset < 0)
+        {
+            return;
+        }
+
+        lock (appendLock)
+        {
+            if (!bufferedTombstones.TryGetValue(path, out var list))
+            {
+                list = new List<long>();
+                bufferedTombstones[path] = list;
+            }
+
+            list.Add(offset);
+        }
+    }
+
+    /// <summary>
+    /// Applies every buffered commit-time tombstone as an in-place negative-prefix marker. Runs
+    /// from <see cref="FlushBufferedAppendsAndOverwrites"/> (the commit path) AFTER the buffered
+    /// appends are on disk, so offsets of rows that were appended AND deleted in the same
+    /// transaction are valid. Rollback discards the buffer instead (<see cref="ClearBufferedAppends"/>).
+    /// </summary>
+    private void ApplyBufferedTombstones()
+    {
+        if (bufferedTombstones.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (path, offsets) in bufferedTombstones)
+        {
+            if (offsets.Count == 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                long fileLength = File.Exists(path) ? new FileInfo(path).Length : 0;
+                foreach (var offset in offsets)
+                {
+                    if (offset >= 0 && offset + 4 <= fileLength)
+                    {
+                        TombstoneRecord(path, offset);
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                // Best-effort: a failed marker leaves the row physical; the auto/explicit
+                // compaction reclaims it later.
+            }
+        }
+
+        bufferedTombstones.Clear();
+    }
+
+    /// <inheritdoc />
     public bool TombstoneRecord(string path, long offset)
     {
         // Read the current slot size so the marker can encode the exact number of bytes to skip
@@ -746,6 +813,7 @@ public partial class Storage
         {
             FlushBufferedAppends();
             FlushBufferedOverwrites();
+            ApplyBufferedTombstones();
         }
     }
 
@@ -822,6 +890,7 @@ public partial class Storage
             cachedFileLengths.Clear();  // ✅ Clear cache too
             headerPendingFiles.Clear(); // ✅ Clear pending header markers on rollback
             bufferedFileBaseLengths.Clear();
+            bufferedTombstones.Clear(); // Rollback: discard pending commit-time tombstones
         }
     }
 

--- a/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
+++ b/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
@@ -218,7 +218,7 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
         }
 
         db.ExecuteBatchSQL(stmts);
-        db.Flush(); // flush-time compaction must physically remove the deleted rows
+        db.Flush(); // commit-time tombstones (or legacy flush compaction) remove the rows physically
         (db as IDisposable)?.Dispose();
 
         db = CreateDb();
@@ -228,6 +228,28 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
         Assert.Equal(100L, Convert.ToInt64(scan[^1]["id"]));
         var c = db.ExecuteQuery("SELECT COUNT(*) AS n FROM docs");
         Assert.Equal(50L, Convert.ToInt64(c[0].Values.First()));
+        (db as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public void BatchDelete_CommitTimeTombstones_SurviveReopenWithoutExplicitFlush()
+    {
+        // ExecuteBatchSQL wraps the whole DELETE batch in one storage transaction. The deleted
+        // positions must be tombstoned AT COMMIT (not at a later db.Flush()), so durability must
+        // hold even when the database is disposed without an explicit Flush afterwards.
+        IDatabase? db = CreateDb();
+        db.ExecuteSQL("CREATE TABLE docs (id INTEGER PRIMARY KEY, name TEXT, score REAL)");
+        InsertDocs(db, 1, 200);
+        db.Flush();
+
+        db.ExecuteBatchSQL(BuildDeletes(1, 100)); // commits inside ExecuteBatchSQL
+        (db as IDisposable)?.Dispose(); // no explicit Flush after the delete batch
+
+        db = CreateDb();
+        var scan = db.ExecuteQuery("SELECT id FROM docs ORDER BY id");
+        Assert.Equal(100, scan.Count);
+        Assert.Equal(101L, Convert.ToInt64(scan[0]["id"]));
+        Assert.Equal(200L, Convert.ToInt64(scan[^1]["id"]));
         (db as IDisposable)?.Dispose();
     }
 }


### PR DESCRIPTION
## Stack
- Base: `perf/b3c4-dml` (**PR #369**) ← `perf/commit-time-tombstones` (**#368**) ← `perf/tombstone-delete` (**#367**) ← master.

## Inhoud
**B1** (`d37fad51`) — key-only DELETE row-decode: de structured batch-DELETE-path (`DeleteMultipleKeys`) bouwt via `BuildDeleteKeyColumns` de benodigde kolomindexen (PK + alle geladen hash-indexkolommen) en decodeert met `DeserializeDeleteKeyRow` alleen díe kolommen uit het legacy variabele-lengte record (payload-parsing van overige kolommen wordt overgeslagen, minimal 1-3-entry dictionary i.p.v. full row). `DeleteRecordsCore` doet daarna dezelfde PK/hash-lookups op die subset. Fixed-width layouts en corrupte rijen vallen terug op de volledige `DeserializeRowFromSpan`.

## Meting (Release, comparative DELETE 10K op ~100K rijen, median van 3)
| | #369 (C4+B3) | B1 |
|---|---:|---:|
| SQL DELETE | ~42K ops/s | ~39K ops/s (39,2 / 38,5 / 44,7) |
| Direct DELETE | ~57K ops/s | ~57K ops/s (50,0 / 56,5 / 58,2) |

**Neutraal binnen run-ruis** op deze small-row workload — de decode was niet de bottleneck (kleine rijen, gepoolde full-row dict). De winst zit in workloads met brede rijen/lange on-geïndexeerde TEXT-payloads (minder UTF8-decode, boxing en dict-writes). Veilig: full suite + 4 CI-filter-suites EXIT=0.

## Conclusie van de meetreeks
De grote sprong zat in **#368** (commit-time tombstones: SQL DELETE 0,82s → 0,24s). C4/B3/B1 zijn robuustheids-/allocatiewinsten die op deze benchmark binnen de ruis vallen. De volgende structurele hefboom is **A1** (contiguous variabele-lengte single-pass UPDATE/DELETE — de docs-tabel heeft fysiek oplopende posities bij oplopende keys, maar alleen fixed-width gebruikt nu de één-range-read) en daarna bulk-B-tree/index-onderhoud.
