### PR TITLE
fix: canonical DELETE scanner + key-only single-index delete (W1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,17 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overflow arena is reclaimed on the next explicit VACUUM/compaction. Regression: delete half the
   rows, `Flush`, reopen ÔÇö exactly the remaining rows come back. Measured DELETE in the `--pk`
   harness now includes this durability rewrite (~18.6K ops/s when deleting 10K of 100K rows).
-- **Durable DELETE is now in-place via tombstones (no rewrite)** ÔÇö non-transactional Columnar
-  deletes write a tombstone marker (the record's 4-byte length prefix is replaced by the NEGATIVE
-  slot size) instead of queueing a flush-time rewrite, and every raw record enumerator/compactor
-  skips the slot, so DELETE survives a reopen in O(delete). Flush/dispose compaction now only
-  covers transactional deletes (a marker written before commit would survive a rollback that
-  restores the row in the PK index; those deletes are compacted against the current PK after commit
-  ÔÇö rollback-safe). Tombstoned space is reclaimed by the tombstone-aware `CompactTable`, including
-  the ULID-migration compaction (which previously produced an empty file when tombstones were
-  present because `CompactTable` broke on a negative prefix). Measured `--pk` DELETE (10K of 100K
-  rows): ~0.54s/18.6K ops/s (flush rewrite) ÔåÆ **~0.16s/~64K ops/s (legacy)** and
-  **~0.12s/~81K ops/s (fixed-width)** ÔÇö DELETE is back on par with UPDATE.
+- **Durable DELETE is now in-place via tombstones (no rewrite)** ÔÇö Columnar deletes write a
+  tombstone marker (the record's 4-byte length prefix is replaced by the NEGATIVE slot size)
+  instead of queueing a flush-time rewrite, and every raw record enumerator/compactor skips the
+  slot, so DELETE survives a reopen in O(delete). Non-transactional deletes write the marker at
+  delete time; transactional deletes (e.g. any `ExecuteBatchSQL` batch, which runs inside a storage
+  transaction) buffer the offsets and apply the markers at COMMIT ÔÇö rollback discards the buffer,
+  so a rolled-back delete keeps its row, and the flush-time full-file rewrite (`CompactPendingDeletes`)
+  is no longer on the batch-DELETE path. Tombstoned space is reclaimed by the tombstone-aware
+  `CompactTable`, including the ULID-migration compaction (which previously produced an empty file
+  when tombstones were present because `CompactTable` broke on a negative prefix). Measured `--pk`
+  DELETE (10K of 100K rows): ~0.54s/18.6K ops/s (flush rewrite) ÔåÆ **~0.16s/~64K ops/s (legacy)** and
+  **~0.13s/~78K ops/s (fixed-width)**; comparative-harness DELETE (docs table): SQL ~0.82s/~12K ÔåÆ
+  **~0.24s/~41K ops/s**, Direct ~0.63s/~16K ÔåÆ **~0.17s/~58K ops/s** ÔÇö DELETE is back on par with UPDATE.
 - **Dedicated SQL batch-INSERT fast path (WP14)** ÔÇö `ExecuteBatchSQL` INSERTs no longer build a
   per-row `Dictionary<string, object>`; VALUES clauses are parsed directly into column-ordered
   `object[]` rows (`PreparedInsertStatement.ParseValuesToArray`) and inserted via the new

--- a/docs/performance/EXECUTION_PLAN_UPDATE_DELETE.md
+++ b/docs/performance/EXECUTION_PLAN_UPDATE_DELETE.md
@@ -1,0 +1,90 @@
+# Uitvoerplan — UPDATE/DELETE-achterstand (combined)
+
+**Datum:** 2026-09-03
+**Bron:** eigen metingen/root-causes (sessie: PR #367–#370) + `PERFORMANCE_DEEP_DIVE.md` (Grok/xAI, second opinion).
+**Status:** actief. Werkwijze: meet eerst (D2), bouw daarna (A1/A2), valideer met median-of-runs + full suite + CI.
+
+## 0. Wat al klaar is (deze sessie)
+| PR | Wat | Effect |
+|---|---|---|
+| #367 | In-place tombstones (directe deletes) | DELETE duurzaam in O(delete), geen flush-rewrite |
+| #368 | **Commit-time tombstones** (transactionele/batch deletes) | **SQL DELETE 0,82 s → 0,24 s** (~12K → ~41-58K ops/s) — de grote sprong |
+| #369 | C4 (batch markers + evict-dedup) + B3 (structured delete, geen dubbele parse) | veilig; neutraal binnen ruis op benchmark |
+| #370 | B1 (key-only decode: alleen PK + hash-indexkolommen) | veilig; neutraal binnen ruis op small-row benchmark |
+
+**Root cause (niet in Grok-doc):** `ExecuteBatchSQL` draait elke batch in een storage-transactie; zonder #368 deed batch-DELETE nog steeds de #366 full-file compactie (~690 ms in `tableFlushLoop`). Daardoor waren eerdere “winst”-metingen niet-duurzaam/logisch-only.
+
+## 1. Baselines & doel
+| | SCDB Direct | SCDB SQL | SQLite | LiteDB |
+|---|---:|---:|---:|---:|
+| INSERT | ~130-187K | ~80-112K | ~130-150K | ~72K |
+| READ | ~127K | ~71K | ~95K | ~15K |
+| UPDATE | ~40-49K | ~34-40K | ~240-275K | ~10K |
+| DELETE | ~55-58K | ~41K | ~325-375K | ~14K |
+
+Cijfers variëren per machine/run (±10-20%). Verdict (beide analyses): niet verloren; **UPDATE/DELETE ~3x achter** is structureel maar aanpakbaar. INSERT/READ + analytics/vector/encryptie zijn al sterke punten.
+
+## 2. Bottlenecks (gecombineerd)
+1. AppendOnly versie-appends: UPDATE/DELETE = pread+pwrite per rij + indexonderhoud (SQLite: in-place leaf + WAL-batch).
+2. Batch-DELETE zat onterecht op flush-compactie → **opgelost (#368)**.
+3. Per-rij punt-I/O + B-tree/hash per operatie (C4/B3/B1 raken de rand, niet de kern — gemeten neutraal).
+4. Volledige (de)serialisatie op in-place paden met leidende variabele-lengte kolommen (deels geraakt door B1).
+5. Contiguïteit wordt alleen voor fixed-width benut (B8/B9); de benchmark-docs-tabel is variabele-lengte met fysiek oplopende posities.
+6. Grove `rwLock` + per-op index-locks.
+7. WAL/fsync-duurzaamheid (bevestigd met split-flush-meting: fsync-tail ~0,5-0,7 s op het oude pad; weg door #368).
+8. Managed/GC + Dictionary/boxing in non-Direct paden.
+9. AES-GCM per record (toggle: `NoEncryptMode`).
+
+## 3. Werkwijze per stap (vóór elke bouw: meten)
+- **D2-first:** profile UPDATE/DELETE hot paths (`DeleteMultipleKeys`/`UpdateMultiple`/`DeleteRecordsCore`/commit-tombstones) met `dotnet-trace` of env-gated fase-timers; bepaal of de tijd zit in resolutie (hash-lookups), per-rij `engine.Read`+decode, indexonderhoud (B-tree/hash), of de commit-markers.
+- Bouw alleen wat het profiel aanwijst. Elke stap: eigen branch → median-of-N benchmark → full suite + 4 CI-filter-suites → doc-update.
+
+## 4. Uitvoeringsfasen
+### Fase A — Quick wins (P0)
+- **A1:** contiguous variabele-lengte single-pass voor UPDATE/DELETE (prefix-walk over oplopende posities; 1 range-read, markers/patches in 1 schrijfpassage). Doel: docs-DELETE/UPDATE ~80-120K. Alleen na D2-bevestiging dat range-I/O de bottleneck is.
+- **A2:** in-place UPDATE waar de slot-lengte gelijk blijft (geen append/stale-versie) voor niet-fastPatch-gevallen.
+- **A3:** batched index re-point per index over de hele batch (deels aanwezig).
+
+### Fase B — Structuur (P1, kern ~3x-achterstand)
+- **B1:** `FixedWidthTable`/in-place page-engine volwassen (vaste offsets, slot-free-space, tombstone+vacuum). Doel: ~120-200K ops/s → ~80-110% van SQLite.
+- **B2:** PageBased als aanbevolen OLTP-engine + storage-engine selector (OLTP→PageBased+FixedWidth; analytics/eventsourcing→AppendOnly/Columnar).
+- **B3:** source-generated typed/ref-struct accessors (geen Dictionary op hot paths) + `PreparedCommand` met herbruikbare buffers.
+- **B4:** fijnmaziger locking (per-page/per-index) + optimistische concurrency.
+
+### Fase C — Platform (P2, .NET 11)
+- **C1:** Native AOT + `Span<T>` + Runtime Async; SIMD lane-API's/AVX-VNNI-512 voor index-lookups.
+- **C2:** optionele “SQLite-compat mode” (NoEncrypt + fixed-width default).
+
+### Fase D — Hygiëne & observability (doorlopend)
+- **D1:** median-of-N + warm-up in de comparative-harness.
+
+## 7. D2-bevindingen (env-gated fase-timers, 2026-09-03)
+DELETE 10K op de docs-tabel (comparative, Release) — attributie in de structured batch path:
+
+| Fase | SQL | Direct |
+|---|---:|---:|
+| per-rij read+decode (`engine.Read`+`DeserializeDeleteKeyRow`) | 62-82 ms | ~66 ms |
+| commit-tombstones (markers, pread+pwrite per rij) | ~50 ms | ~48-50 ms |
+| delete core (index-onderhoud, B-tree/hash) | 23-56 ms | ~32 ms |
+| hash-index lookup | 5-10 ms | ~5 ms |
+
+**Ontdekte bug (gefixed):** `TryScanCanonicalDml`'s DELETE-tak consumente nooit de whitespace/het `WHERE`-keyword na de tabelnaam → elke canonieke `DELETE ... WHERE col = literal` viel terug op de regex-path → `DeleteMultipleKeys` + B1/W1 (PR #369/#370) waren **dead code in de benchmark-harness**. Fix + diagnostische teller `Database.CanonicalDeleteStatementsParsed` + regressietest `CanonicalBatchDelete_EngagesStructuredPath` (deze PR).
+
+**Gevolg voor de attributie:** de per-rij read blijft nodig zolang de delete-core de auto-`rowid`-PK-waarde per rij moet wissen (gate-onderzoek: docs heeft PK-achtige index >1 geregistreerd). Grootste resterende hefbomen, nu met cijfers onderbouwd:
+1. **PK-onderhoud vervangen door één stale/lazy-rebuild** na een grote delete-batch (i.p.v. per-rij `Index.Delete`) → verwijdert ~30-50% van `core` én maakt de per-rij read overbodig (grootste winst op deze workload).
+2. **Marker-batching over een range-read** (commit-tombstones ~50 ms → enkele ms) als vervolg op C4.
+3. W1 (key-only, geen read) vuurt alleen bij een tabel met exact één geregistreerde index en zonder PK-tree — daar direct ~60-80 ms winst per 10K deletes.
+
+- **D2:** `dotnet-trace`/fase-timers op `UpdateAffectedRows`, `DeleteMultipleKeys`, `DeleteRecordsCore`, commit-tombstones.
+- **D3:** AOT/R2R expliciet als aparte meet-as (we meten nu managed JIT + tiered PGO).
+- **D4:** `docs/manual/performance.md` + dit document bijwerken na elke stap.
+
+## 5. Beslisboom (storage-engine)
+- Veel UPDATE/DELETE (OLTP) → **PageBased + FixedWidth** (in-place).
+- Veel appends/analytics/eventsourcing → **AppendOnly/Columnar** (blijft dominant).
+- Pure-throughput scenario’s → `NoEncryptMode`; encryptie blijft default-differentiator.
+
+## 6. Volgende acties
+1. D2-profiel op de huidige DELETE/UPDATE hot paths.
+2. A1/A2 implementeren op basis van het profiel (branch bovenop #370).
+3. Fase B (fixed-width in-place + PageBased default) als aparte roadmap-track.

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -3059,6 +3059,9 @@ public partial class Table
                 }
             }
 
+            // B1: decode only the columns the delete core touches (PK + loaded hash-index columns).
+            int[] deleteKeyColumns = BuildDeleteKeyColumns();
+
             var recordsToDelete = new List<(long storagePosition, Dictionary<string, object> row)>();
 
             foreach (var (col, literal) in conditions)
@@ -3076,7 +3079,7 @@ public partial class Table
                         var fastData = engine.Read(Name, fastSearch.Value);
                         if (fastData != null)
                         {
-                            var fastRow = DeserializeRowFromSpan(fastData);
+                            var fastRow = DeserializeDeleteKeyRow(fastData, deleteKeyColumns) ?? DeserializeRowFromSpan(fastData);
                             if (fastRow != null)
                             {
                                 recordsToDelete.Add((fastSearch.Value, fastRow));
@@ -3103,7 +3106,7 @@ public partial class Table
                                     var data = engine.Read(Name, pos);
                                     if (data != null)
                                     {
-                                        var row = DeserializeRowFromSpan(data);
+                                        var row = DeserializeDeleteKeyRow(data, deleteKeyColumns) ?? DeserializeRowFromSpan(data);
                                         if (row != null) recordsToDelete.Add((pos, row));
                                     }
                                 }
@@ -3173,6 +3176,78 @@ public partial class Table
     private static string UnquoteSqlLiteral(string raw)
     {
         return raw.AsSpan().Trim().Trim("'\"".AsSpan()).ToString();
+    }
+
+    /// <summary>
+    /// B1: column indexes a delete target actually needs — the PK value (B-tree cleanup) plus every
+    /// loaded hash-index column (key-only hash cleanup). Ascending, de-duplicated.
+    /// </summary>
+    private int[] BuildDeleteKeyColumns()
+    {
+        var list = new List<int>(4);
+        if (this.PrimaryKeyIndex >= 0)
+        {
+            list.Add(this.PrimaryKeyIndex);
+        }
+
+        foreach (var kvp in this.hashIndexes)
+        {
+            int colIdx = this.Columns.IndexOf(kvp.Key);
+            if (colIdx >= 0 && !list.Contains(colIdx))
+            {
+                list.Add(colIdx);
+            }
+        }
+
+        list.Sort();
+        return list.ToArray();
+    }
+
+    /// <summary>
+    /// B1: decodes only the columns listed in <paramref name="wanted"/> (ascending) from a legacy
+    /// variable-length serialized row, skipping the unneeded columns' payload parsing entirely.
+    /// Returns a minimal dictionary (pk + hash-index columns only) so <see cref="DeleteRecordsCore"/>
+    /// performs the identical PK/hash lookups without materializing the full row. Returns null for
+    /// fixed-width layouts (those go through the fixed-width codec) or corrupt rows — callers fall
+    /// back to full-row deserialization in that case.
+    /// </summary>
+    private Dictionary<string, object>? DeserializeDeleteKeyRow(byte[] data, int[] wanted)
+    {
+        if (_fixedWidthRecords || data == null || data.Length == 0 || wanted.Length == 0)
+        {
+            return null;
+        }
+
+        ReadOnlySpan<byte> span = data.AsSpan();
+        int offset = 0;
+        Dictionary<string, object>? row = null;
+        int wi = 0;
+
+        for (int i = 0; i < Columns.Count; i++)
+        {
+            if (offset >= span.Length)
+            {
+                return null;
+            }
+
+            int size = ReadColumnEncodedSize(span, offset, ColumnTypes[i]);
+            if (size <= 0 || offset + size > span.Length)
+            {
+                return null; // corrupt / unexpected layout → full-row fallback
+            }
+
+            if (wi < wanted.Length && wanted[wi] == i)
+            {
+                var value = ReadTypedValueFromSpan(span.Slice(offset), ColumnTypes[i], out _);
+                row ??= new Dictionary<string, object>(wanted.Length);
+                row[Columns[i]] = value;
+                wi++;
+            }
+
+            offset += size;
+        }
+
+        return row;
     }
 
     /// <summary>

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -3022,6 +3022,160 @@ public partial class Table
     }
 
     /// <summary>
+    /// Structured variant of <see cref="DeleteMultiple"/> used by the SQL batch dispatcher for
+    /// canonical single-row DELETE statements (`DELETE FROM t WHERE col = literal`, as detected by
+    /// the canonical-DML scanner). The WHERE column and raw literal are already known, so the
+    /// per-statement `col = literal` string rebuild and the second <see cref="TryParseSimpleWhereClause"/>
+    /// pass are skipped on the hot path. Semantics mirror <see cref="DeleteMultiple"/> exactly
+    /// (PK fast path → hash-index fast path → generic fallback with a lazily rebuilt WHERE string,
+    /// only reached for unusual shapes).
+    /// </summary>
+    /// <param name="conditions">Column name and RAW literal value (quotes as written in SQL).</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    internal void DeleteMultipleKeys(List<(string Column, string Literal)> conditions)
+    {
+        if (this.isReadOnly) throw new InvalidOperationException(ReadOnlyDeleteError);
+        if (conditions.Count == 0) return;
+
+        this.rwLock.EnterWriteLock();
+        try
+        {
+            var engine = GetOrCreateStorageEngine();
+            EnsureAllRegisteredIndexesLoaded();
+
+            // B9 single-pass contiguous DELETE consumes WHERE strings; attempt it (without touching
+            // anything) only when every condition is a literal on the PK column, like the caller.
+            if (this.PrimaryKeyIndex >= 0 && AllPkLiteralConditions(conditions))
+            {
+                var wheres = new List<string>(conditions.Count);
+                foreach (var (col, literal) in conditions)
+                {
+                    wheres.Add(col + " = " + literal);
+                }
+
+                if (TryBulkDeleteContiguousFixedWidth(wheres))
+                {
+                    return;
+                }
+            }
+
+            var recordsToDelete = new List<(long storagePosition, Dictionary<string, object> row)>();
+
+            foreach (var (col, literal) in conditions)
+            {
+                string value = UnquoteSqlLiteral(literal);
+
+                // Issue #7 PK fast path (structured: no WHERE-string re-parse).
+                if (StorageMode != StorageMode.PageBased &&
+                    this.PrimaryKeyIndex >= 0 &&
+                    string.Equals(col, this.Columns[this.PrimaryKeyIndex], StringComparison.OrdinalIgnoreCase))
+                {
+                    var fastSearch = this.Index.Search(value);
+                    if (fastSearch.Found)
+                    {
+                        var fastData = engine.Read(Name, fastSearch.Value);
+                        if (fastData != null)
+                        {
+                            var fastRow = DeserializeRowFromSpan(fastData);
+                            if (fastRow != null)
+                            {
+                                recordsToDelete.Add((fastSearch.Value, fastRow));
+                            }
+                        }
+
+                        continue;
+                    }
+                }
+                // Hash index fast path.
+                if (this.registeredIndexes.ContainsKey(col))
+                {
+                    EnsureIndexLoaded(col);
+                    if (this.hashIndexes.TryGetValue(col, out var hashIndex))
+                    {
+                        var colIdx = this.Columns.IndexOf(col);
+                        if (colIdx >= 0)
+                        {
+                            var key = ParseValueForHashLookup(value, this.ColumnTypes[colIdx]);
+                            if (key != null)
+                            {
+                                foreach (var pos in hashIndex.LookupPositionsUnsafe(key))
+                                {
+                                    var data = engine.Read(Name, pos);
+                                    if (data != null)
+                                    {
+                                        var row = DeserializeRowFromSpan(data);
+                                        if (row != null) recordsToDelete.Add((pos, row));
+                                    }
+                                }
+
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                // Generic fallback (rare for canonical shapes): rebuild the WHERE string exactly as
+                // the caller would have and mirror DeleteMultiple.
+                string where = col + " = " + literal;
+                if (this.PrimaryKeyIndex >= 0)
+                {
+                    var rows = SelectInternal(where, orderBy: null, asc: true, noEncrypt: false);
+                    var pkCol = this.Columns[this.PrimaryKeyIndex];
+                    foreach (var row in rows)
+                    {
+                        if (row.TryGetValue(pkCol, out var pkValue) && pkValue != null)
+                        {
+                            var searchResult = this.Index.Search(pkValue.ToString() ?? string.Empty);
+                            if (searchResult.Found)
+                                recordsToDelete.Add((searchResult.Value, row));
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var (storageRef, data) in engine.GetAllRecords(Name))
+                    {
+                        var row = DeserializeRowFromSpan(data);
+                        if (row != null && (string.IsNullOrEmpty(where) || EvaluateSimpleWhere(row, where)))
+                            recordsToDelete.Add((storageRef, row));
+                    }
+                }
+            }
+
+            if (recordsToDelete.Count == 0) return;
+
+            DeleteRecordsCore(recordsToDelete);
+        }
+        finally
+        {
+            this.rwLock.ExitWriteLock();
+        }
+    }
+
+    private bool AllPkLiteralConditions(List<(string Column, string Literal)> conditions)
+    {
+        var pkCol = this.Columns[this.PrimaryKeyIndex];
+        foreach (var (col, _) in conditions)
+        {
+            if (!string.Equals(col, pkCol, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Mirrors the value normalization of <see cref="TryParseSimpleWhereClause"/> (trim whitespace,
+    /// then trim enclosing <c>'</c>/<c>"</c> quotes) on a raw SQL literal.
+    /// </summary>
+    private static string UnquoteSqlLiteral(string raw)
+    {
+        return raw.AsSpan().Trim().Trim("'\"".AsSpan()).ToString();
+    }
+
+    /// <summary>
     /// Shared B8/B9 probe: resolves each key's record position through the PK B-tree, requires the
     /// positions to be physically adjacent at the fixed-width stride, reads the whole contiguous
     /// span through the storage layer's cached handle and verifies every 4-byte length prefix.

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -2655,11 +2655,16 @@ public partial class Table
 
             if (this.storage is { IsInTransaction: true })
             {
-                // Transactional delete: writing the tombstone now would survive a rollback that
-                // restores the row in the PK index, so defer the physical removal to the post-commit
-                // flush compaction (rollback-safe: that rewrite is driven by the CURRENT PK, which
-                // still contains the row after a rollback).
-                Interlocked.Add(ref _pendingLogicalDeletes, recordsToDelete.Count);
+                // Transactional delete: buffer the physical offsets so the in-place marker is
+                // applied at COMMIT (rollback discards the buffer). Durable in O(delete) — the
+                // flush-time full-file rewrite is no longer needed for transactional deletes.
+                foreach (var position in positions)
+                {
+                    if (position >= 0)
+                    {
+                        this.storage.BufferTombstoneForCommit(DataFile, position);
+                    }
+                }
             }
             else
             {
@@ -3214,9 +3219,15 @@ public partial class Table
 
         if (this.storage is { IsInTransaction: true })
         {
-            // Transactional delete: defer physical removal to the post-commit flush compaction
-            // (see DeleteRecordsCore — a tombstone would survive a rollback that restores the row).
-            Interlocked.Add(ref _pendingLogicalDeletes, count);
+            // Transactional delete: buffer the physical offsets so the in-place marker is applied
+            // at COMMIT (see DeleteRecordsCore — rollback discards the buffer).
+            foreach (var position in positions)
+            {
+                if (position >= 0)
+                {
+                    this.storage.BufferTombstoneForCommit(DataFile, position);
+                }
+            }
         }
         else
         {

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -3101,6 +3101,30 @@ public partial class Table
                             var key = ParseValueForHashLookup(value, this.ColumnTypes[colIdx]);
                             if (key != null)
                             {
+                                // W1: when this is the ONLY index the delete core must maintain (no
+                                // PK tree, a single loaded hash index whose key is the condition
+                                // value itself, no secondary B-tree manager), the position can be
+                                // removed with the already-known key — no per-row engine.Read or row
+                                // decode is needed for index cleanup.
+                                bool keyOnlyRow =
+                                    this.PrimaryKeyIndex < 0 &&
+                                    this.hashIndexes.Count == 1 &&
+                                    _btreeManager is null &&
+                                    this.registeredIndexes.Count == 1;
+
+                                if (keyOnlyRow)
+                                {
+                                    foreach (var pos in hashIndex.LookupPositionsUnsafe(key))
+                                    {
+                                        recordsToDelete.Add((pos, new Dictionary<string, object>(1)
+                                        {
+                                            [col] = key
+                                        }));
+                                    }
+
+                                    continue;
+                                }
+
                                 foreach (var pos in hashIndex.LookupPositionsUnsafe(key))
                                 {
                                     var data = engine.Read(Name, pos);

--- a/src/SharpCoreDB/DataStructures/Table.Compaction.cs
+++ b/src/SharpCoreDB/DataStructures/Table.Compaction.cs
@@ -8,7 +8,6 @@ namespace SharpCoreDB.DataStructures;
 using SharpCoreDB.Storage.Engines;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -113,7 +112,8 @@ public partial class Table
     /// present in the data file, making the Columnar logical delete durable across reopen (readers
     /// skip the marker) without rewriting the remaining rows. Rows appended inside an uncommitted
     /// transaction (positions beyond the current file length) are skipped — their delete commits
-    /// with the rest of the transaction.
+    /// with the rest of the transaction. The storage layer batches the in-place marker writes and
+    /// de-duplicates page-cache evictions per page.
     /// </summary>
     private void TombstoneDeletedPositions(long[] positions)
     {
@@ -122,14 +122,7 @@ public partial class Table
             return;
         }
 
-        long fileLength = File.Exists(DataFile) ? new FileInfo(DataFile).Length : 0;
-        foreach (var position in positions)
-        {
-            if (position >= 0 && position + 4 <= fileLength)
-            {
-                this.storage.TombstoneRecord(DataFile, position);
-            }
-        }
+        this.storage.TombstoneRecords(DataFile, positions);
     }
 
     /// <summary>

--- a/src/SharpCoreDB/Database/Core/Database.Core.cs
+++ b/src/SharpCoreDB/Database/Core/Database.Core.cs
@@ -32,6 +32,11 @@ using System.Threading;
 /// </summary>
 public partial class Database : IDatabase, IDisposable, IAsyncDisposable
 {
+    // Diagnostics: number of DELETE statements routed through the canonical structured batch path
+    // (proves the scanner/batch fast paths are engaged; 0 means everything fell back to regex).
+    private static long _canonicalDeleteStatements;
+    public long CanonicalDeleteStatementsParsed => Interlocked.Read(ref _canonicalDeleteStatements);
+
     private readonly IServiceProvider _serviceProvider;
     private readonly IStorage storage;
     private readonly IUserService userService;

--- a/src/SharpCoreDB/Database/Execution/Database.Batch.cs
+++ b/src/SharpCoreDB/Database/Execution/Database.Batch.cs
@@ -616,6 +616,18 @@ public partial class Database
                 return false;
             }
         }
+        else
+        {
+            // DELETE: consume the whitespace after the table name, then the WHERE keyword, then
+            // the whitespace before the WHERE column. (Missing before — every canonical DELETE fell
+            // back to the regex path, bypassing the structured batch-DELETE fast paths.)
+            if (!TryConsumeWhitespace(s, ref i) ||
+                !TryConsumeKeyword(s, ref i, "WHERE") ||
+                !TryConsumeWhitespace(s, ref i))
+            {
+                return false;
+            }
+        }
 
         // WHERE <col> = <literal> (to end of statement)
         if (!TryReadSimpleIdent(s, ref i, out var whereColSpan) || whereColSpan.IsEmpty)
@@ -944,6 +956,7 @@ public partial class Database
             whereLiteral = whereValRaw;
             // Where stays empty for canonical statements — the table layer reconstructs it only
             // when a fallback actually needs it (B3: no per-statement string allocation).
+            System.Threading.Interlocked.Increment(ref _canonicalDeleteStatements);
             return true;
         }
 

--- a/src/SharpCoreDB/Database/Execution/Database.Batch.cs
+++ b/src/SharpCoreDB/Database/Execution/Database.Batch.cs
@@ -923,10 +923,12 @@ public partial class Database
     /// <param name="tableName">The parsed table name.</param>
     /// <param name="where">The parsed WHERE clause.</param>
     /// <returns>True if the statement was successfully parsed as a DELETE.</returns>
-    private bool TryParseDeleteForBatch(string sql, out string tableName, out string where)
+    private bool TryParseDeleteForBatch(string sql, out string tableName, out string where, out string? whereColumn, out string? whereLiteral)
     {
         tableName = string.Empty;
         where = string.Empty;
+        whereColumn = null;
+        whereLiteral = null;
 
         // Phase-2 fast path: canonical single-row shape
         // `DELETE FROM <table> WHERE <col> = <literal>` — regex-free.
@@ -938,7 +940,10 @@ public partial class Database
             }
 
             tableName = fastTable;
-            where = whereCol + " = " + whereValRaw;
+            whereColumn = whereCol;
+            whereLiteral = whereValRaw;
+            // Where stays empty for canonical statements — the table layer reconstructs it only
+            // when a fallback actually needs it (B3: no per-statement string allocation).
             return true;
         }
 
@@ -997,7 +1002,9 @@ public partial class Database
 
         // ✅ PERF: Group UPDATE/DELETE by table for single-lock batch execution
         Dictionary<string, List<(string where, Dictionary<string, object> updates)>> updatesByTable = [];
-        Dictionary<string, List<string>> deletesByTable = [];
+        // Canonical DELETE statements carry the pre-parsed column + raw literal so the table layer
+        // can skip the per-statement WHERE rebuild/re-parse (B3); Where stays empty for those.
+        Dictionary<string, List<(string Where, string? Column, string? Literal)>> deletesByTable = [];
 
         foreach (var sql in statements)
         {
@@ -1031,14 +1038,14 @@ public partial class Database
                 }
                 updList.Add((updWhere, updSets));
             }
-            else if (TryParseDeleteForBatch(sql, out var delTableName, out var delWhere))
+            else if (TryParseDeleteForBatch(sql, out var delTableName, out var delWhere, out var delCol, out var delLiteral))
             {
                 if (!deletesByTable.TryGetValue(delTableName, out var delList))
                 {
                     delList = [];
                     deletesByTable[delTableName] = delList;
                 }
-                delList.Add(delWhere);
+                delList.Add((delWhere, delCol, delLiteral));
             }
             else
             {
@@ -1097,11 +1104,42 @@ public partial class Database
                 }
 
                 // ✅ PERF: Batch DELETE — single lock per table instead of per-statement
-                foreach (var (tableName, wheres) in deletesByTable)
+                foreach (var (tableName, deletes) in deletesByTable)
                 {
                     if (tables.TryGetValue(tableName, out var tbl) && tbl is DataStructures.Table concreteDelete)
                     {
-                        concreteDelete.DeleteMultiple(wheres);
+                        // Canonical batches go through the structured path (no WHERE rebuild/re-parse);
+                        // any non-canonical statement forces the string form for the whole table.
+                        bool allCanonical = true;
+                        foreach (var (_, column, _) in deletes)
+                        {
+                            if (column is null)
+                            {
+                                allCanonical = false;
+                                break;
+                            }
+                        }
+
+                        if (allCanonical)
+                        {
+                            var keys = new List<(string Column, string Literal)>(deletes.Count);
+                            foreach (var (_, column, literal) in deletes)
+                            {
+                                keys.Add((column!, literal!));
+                            }
+
+                            concreteDelete.DeleteMultipleKeys(keys);
+                        }
+                        else
+                        {
+                            var wheres = new List<string>(deletes.Count);
+                            foreach (var (where, column, literal) in deletes)
+                            {
+                                wheres.Add(where.Length > 0 ? where : column + " = " + literal);
+                            }
+
+                            concreteDelete.DeleteMultiple(wheres);
+                        }
                     }
                 }
 

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -180,6 +180,16 @@ public interface IStorage
     bool TombstoneRecord(string path, long offset) => false;
 
     /// <summary>
+    /// Registers a record position to be tombstoned when the CURRENT transaction commits. Deletes
+    /// issued inside a transaction must not write the marker at delete time (it would survive a
+    /// rollback that restores the row), so callers buffer the physical offset here and the storage
+    /// layer applies the in-place marker once the owning transaction commits — durable in O(delete)
+    /// without the flush-time full-file rewrite. On rollback the buffered offsets are discarded.
+    /// The default is a no-op (unsupported layout / mock storage).
+    /// </summary>
+    void BufferTombstoneForCommit(string path, long offset) { }
+
+    /// <summary>
     /// Enumerates every record in a table data file, yielding the literal file offset of the
     /// 4-byte length prefix (the offset returned by <see cref="AppendBytes"/>) together with the
     /// decrypted (or plaintext) record payload. Format-agnostic: transparently handles both legacy

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -190,6 +190,25 @@ public interface IStorage
     void BufferTombstoneForCommit(string path, long offset) { }
 
     /// <summary>
+    /// Bulk <see cref="TombstoneRecord"/>: marks every listed record offset as deleted. The default
+    /// implementation applies <see cref="TombstoneRecord"/> per offset (for alternative/mock
+    /// <see cref="IStorage"/> implementations); the real storage backend batches the in-place
+    /// marker writes and de-duplicates page-cache evictions per page.
+    /// </summary>
+    void TombstoneRecords(string path, long[] offsets)
+    {
+        if (offsets is null)
+        {
+            return;
+        }
+
+        foreach (var offset in offsets)
+        {
+            TombstoneRecord(path, offset);
+        }
+    }
+
+    /// <summary>
     /// Enumerates every record in a table data file, yielding the literal file offset of the
     /// 4-byte length prefix (the offset returned by <see cref="AppendBytes"/>) together with the
     /// decrypted (or plaintext) record payload. Format-agnostic: transparently handles both legacy

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -609,22 +609,7 @@ public partial class Storage
                 continue;
             }
 
-            try
-            {
-                long fileLength = File.Exists(path) ? new FileInfo(path).Length : 0;
-                foreach (var offset in offsets)
-                {
-                    if (offset >= 0 && offset + 4 <= fileLength)
-                    {
-                        TombstoneRecord(path, offset);
-                    }
-                }
-            }
-            catch (IOException)
-            {
-                // Best-effort: a failed marker leaves the row physical; the auto/explicit
-                // compaction reclaims it later.
-            }
+            TombstoneRecords(path, offsets.ToArray());
         }
 
         bufferedTombstones.Clear();
@@ -678,6 +663,60 @@ public partial class Storage
         }
 
         return true;
+    }
+
+    /// <inheritdoc />
+    public void TombstoneRecords(string path, long[] offsets)
+    {
+        if (offsets == null || offsets.Length == 0)
+        {
+            return;
+        }
+
+        HashSet<int>? pagesToEvict = this.pageCache != null ? new HashSet<int>() : null;
+
+        try
+        {
+            SafeFileHandle readHandle = GetOrOpenReadHandle(path);
+            Span<byte> lengthBuffer = stackalloc byte[4];
+            Span<byte> marker = stackalloc byte[4];
+
+            foreach (var offset in offsets)
+            {
+                if (offset < 0)
+                {
+                    continue;
+                }
+
+                if (RandomAccess.Read(readHandle, lengthBuffer, offset) != 4)
+                {
+                    continue; // offset at/beyond EOF — not a physical record
+                }
+
+                int currentLength = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
+                if (currentLength <= 0)
+                {
+                    continue; // already tombstoned or invalid
+                }
+
+                BinaryPrimitives.WriteInt32LittleEndian(marker, -(4 + currentLength));
+                WriteRecordInPlace(path, offset, marker, ReadOnlySpan<byte>.Empty);
+
+                pagesToEvict?.Add(ComputePageId(path, offset));
+            }
+        }
+        catch (IOException)
+        {
+            return;
+        }
+
+        if (pagesToEvict != null)
+        {
+            foreach (var pageId in pagesToEvict)
+            {
+                this.pageCache!.EvictPage(pageId);
+            }
+        }
     }
 
     /// <inheritdoc />

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -49,6 +49,12 @@ public partial class Storage
     // append because OverwriteRecordAt refused to write inside a transaction.
     private readonly ConcurrentDictionary<string, Dictionary<long, byte[]>> bufferedOverwrites = new(StringComparer.Ordinal);
 
+    // ✅ Commit-time tombstones: physical offsets of records deleted inside the current
+    // transaction. The marker is NOT written at delete time (a rollback must keep the row);
+    // ApplyBufferedTombstones writes the in-place negative-prefix markers when the transaction
+    // commits, after the buffered appends are on disk. Rollback discards the buffer.
+    private readonly Dictionary<string, List<long>> bufferedTombstones = new(StringComparer.Ordinal);
+
     // Base file length captured at the first buffered operation of the transaction. In-place
     // overwrites are only safe below this boundary (records already flushed to disk); offsets
     // at or above it belong to still-buffered appends and must fall back to append.
@@ -564,6 +570,67 @@ public partial class Storage
     public bool AreRecordsEncrypted(string path) => UseRecordEncryption && FileHasEncryptedHeader(path);
 
     /// <inheritdoc />
+    public void BufferTombstoneForCommit(string path, long offset)
+    {
+        if (offset < 0)
+        {
+            return;
+        }
+
+        lock (appendLock)
+        {
+            if (!bufferedTombstones.TryGetValue(path, out var list))
+            {
+                list = new List<long>();
+                bufferedTombstones[path] = list;
+            }
+
+            list.Add(offset);
+        }
+    }
+
+    /// <summary>
+    /// Applies every buffered commit-time tombstone as an in-place negative-prefix marker. Runs
+    /// from <see cref="FlushBufferedAppendsAndOverwrites"/> (the commit path) AFTER the buffered
+    /// appends are on disk, so offsets of rows that were appended AND deleted in the same
+    /// transaction are valid. Rollback discards the buffer instead (<see cref="ClearBufferedAppends"/>).
+    /// </summary>
+    private void ApplyBufferedTombstones()
+    {
+        if (bufferedTombstones.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (path, offsets) in bufferedTombstones)
+        {
+            if (offsets.Count == 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                long fileLength = File.Exists(path) ? new FileInfo(path).Length : 0;
+                foreach (var offset in offsets)
+                {
+                    if (offset >= 0 && offset + 4 <= fileLength)
+                    {
+                        TombstoneRecord(path, offset);
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                // Best-effort: a failed marker leaves the row physical; the auto/explicit
+                // compaction reclaims it later.
+            }
+        }
+
+        bufferedTombstones.Clear();
+    }
+
+    /// <inheritdoc />
     public bool TombstoneRecord(string path, long offset)
     {
         // Read the current slot size so the marker can encode the exact number of bytes to skip
@@ -746,6 +813,7 @@ public partial class Storage
         {
             FlushBufferedAppends();
             FlushBufferedOverwrites();
+            ApplyBufferedTombstones();
         }
     }
 
@@ -822,6 +890,7 @@ public partial class Storage
             cachedFileLengths.Clear();  // ✅ Clear cache too
             headerPendingFiles.Clear(); // ✅ Clear pending header markers on rollback
             bufferedFileBaseLengths.Clear();
+            bufferedTombstones.Clear(); // Rollback: discard pending commit-time tombstones
         }
     }
 

--- a/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
+++ b/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
@@ -232,6 +232,31 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
     }
 
     [Fact]
+    public void CanonicalBatchDelete_EngagesStructuredPath()
+    {
+        // Regression: TryScanCanonicalDml's DELETE branch did not consume whitespace/WHERE after
+        // the table name, so every canonical `DELETE ... WHERE col = literal` fell back to the
+        // regex path and bypassed the structured batch-DELETE fast paths (DeleteMultipleKeys).
+        IDatabase? db = CreateDb();
+        try
+        {
+            db.ExecuteSQL("CREATE TABLE docs (id INTEGER PRIMARY KEY, name TEXT, score REAL)");
+            InsertDocs(db, 1, 50);
+            db.Flush();
+
+            var before = ((SharpCoreDB.Database)db).CanonicalDeleteStatementsParsed;
+            db.ExecuteBatchSQL(BuildDeletes(1, 10));
+            db.Flush();
+
+            Assert.True(
+                ((SharpCoreDB.Database)db).CanonicalDeleteStatementsParsed >= before + 10,
+                "canonical DELETE statements must flow through the structured batch path");
+            Assert.Equal(40, db.ExecuteQuery("SELECT id FROM docs").Count);
+        }
+        finally { (db as IDisposable)?.Dispose(); }
+    }
+
+    [Fact]
     public void BatchDelete_CommitTimeTombstones_SurviveReopenWithoutExplicitFlush()
     {
         // ExecuteBatchSQL wraps the whole DELETE batch in one storage transaction. The deleted

--- a/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
+++ b/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
@@ -218,7 +218,7 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
         }
 
         db.ExecuteBatchSQL(stmts);
-        db.Flush(); // flush-time compaction must physically remove the deleted rows
+        db.Flush(); // commit-time tombstones (or legacy flush compaction) remove the rows physically
         (db as IDisposable)?.Dispose();
 
         db = CreateDb();
@@ -228,6 +228,28 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
         Assert.Equal(100L, Convert.ToInt64(scan[^1]["id"]));
         var c = db.ExecuteQuery("SELECT COUNT(*) AS n FROM docs");
         Assert.Equal(50L, Convert.ToInt64(c[0].Values.First()));
+        (db as IDisposable)?.Dispose();
+    }
+
+    [Fact]
+    public void BatchDelete_CommitTimeTombstones_SurviveReopenWithoutExplicitFlush()
+    {
+        // ExecuteBatchSQL wraps the whole DELETE batch in one storage transaction. The deleted
+        // positions must be tombstoned AT COMMIT (not at a later db.Flush()), so durability must
+        // hold even when the database is disposed without an explicit Flush afterwards.
+        IDatabase? db = CreateDb();
+        db.ExecuteSQL("CREATE TABLE docs (id INTEGER PRIMARY KEY, name TEXT, score REAL)");
+        InsertDocs(db, 1, 200);
+        db.Flush();
+
+        db.ExecuteBatchSQL(BuildDeletes(1, 100)); // commits inside ExecuteBatchSQL
+        (db as IDisposable)?.Dispose(); // no explicit Flush after the delete batch
+
+        db = CreateDb();
+        var scan = db.ExecuteQuery("SELECT id FROM docs ORDER BY id");
+        Assert.Equal(100, scan.Count);
+        Assert.Equal(101L, Convert.ToInt64(scan[0]["id"]));
+        Assert.Equal(200L, Convert.ToInt64(scan[^1]["id"]));
         (db as IDisposable)?.Dispose();
     }
 }


### PR DESCRIPTION
## Stack
- Base: `perf/keyonly-delete` (**PR #370**) ← #369 ← #368 ← #367 ← master.

## Inhoud
1. **fix: canonieke DELETE-scanner** — `TryScanCanonicalDml`'s DELETE-tak consumente nooit de whitespace/het `WHERE`-keyword na de tabelnaam → elke canonieke `DELETE ... WHERE col = literal` viel terug op de regex-path. Gevolg: `DeleteMultipleKeys` + B1 (#370) waren **dead code in de benchmark-harness** (verklaart waarom #369/#370 neutraal leken). Nu routeren canonieke batch-deletes door de structured path.
2. **Diagnostiek:** `Database.CanonicalDeleteStatementsParsed` + regressietest `CanonicalBatchDelete_EngagesStructuredPath`.
3. **W1 (key-only no-read):** in `DeleteMultipleKeys`, wanneer de tabel geen PK-tree heeft en exact één geregistreerde hash-index (geen B-tree manager) waarvan de key de conditiewaarde is, worden posities met de bekende key verwijderd — géén per-rij `engine.Read`/decode.
4. **docs/performance/EXECUTION_PLAN_UPDATE_DELETE.md** — gecombineerd uitvoerdocument (eigen analyse + Grok second opinion) incl. D2-bevindingen.

## D2-attributie (env-gated fase-timers, DELETE 10K docs-tabel)
| Fase | SQL | Direct |
|---|---:|---:|
| per-rij read+decode | 62-82 ms | ~66 ms |
| commit-tombstones | ~50 ms | ~48 ms |
| core (index/B-tree) | 23-56 ms | ~32 ms |
| hash-lookup | 5-10 ms | ~5 ms |

Grote vervolg-hefboom met deze cijfers: de per-rij read + per-rij `Index.Delete` (auto-rowid-PK) vervangen door één **batch PK stale/lazy-rebuild** na een grote delete-batch.

## Validatie
- Full `SharpCoreDB.Tests` (Debug) + Release/CI-filter op alle vier de suites: **EXIT=0**.
- Release benchmark DELETE blijft ~43-50K ops/s (scanner-fix is voor deze harness gedrag-neutraal; W1 raakt alleen single-index-zonder-PK tabellen).
