### PR TITLE
perf: whole-file range read for DELETE tombstone markers

### DIFF
--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -35,6 +35,9 @@ public partial class Storage
     /// <summary>Maximum accepted record/ciphertext length (1 GB).</summary>
     private const int MaxRecordSize = 1_000_000_000;
 
+    /// <summary>Upper bound for the whole-file tombstone-marker range read (DELETE commit path).</summary>
+    private const long RangeMarkerReadLimitBytes = 32 * 1024 * 1024;
+
     /// <summary>AES-GCM overhead = nonce(12) + tag(16).</summary>
     private const int GcmOverhead = CryptoConstants.GCM_NONCE_SIZE + CryptoConstants.GCM_TAG_SIZE;
 
@@ -681,28 +684,70 @@ public partial class Storage
             Span<byte> lengthBuffer = stackalloc byte[4];
             Span<byte> marker = stackalloc byte[4];
 
-            foreach (var offset in offsets)
+            // Range fast path: for a large batch on a bounded file, read the whole file ONCE and
+            // resolve every record length from the buffer instead of one pread per offset (the
+            // per-marker pread dominated the DELETE commit in profiling: ~50ms/10K markers).
+            long fileLength = 0;
+            byte[]? wholeFile = null;
+            if (offsets.Length >= 64)
             {
-                if (offset < 0)
+                fileLength = File.Exists(path) ? new FileInfo(path).Length : 0;
+                if (fileLength > 0 && fileLength <= RangeMarkerReadLimitBytes && fileLength <= int.MaxValue)
                 {
-                    continue;
+                    wholeFile = new byte[(int)fileLength];
+                    if (RandomAccess.Read(readHandle, wholeFile, 0) != fileLength)
+                    {
+                        wholeFile = null;
+                    }
                 }
+            }
 
-                if (RandomAccess.Read(readHandle, lengthBuffer, offset) != 4)
+            if (wholeFile is not null)
+            {
+                foreach (var offset in offsets)
                 {
-                    continue; // offset at/beyond EOF — not a physical record
-                }
+                    if (offset < 0 || offset + 4 > wholeFile.Length)
+                    {
+                        continue;
+                    }
 
-                int currentLength = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
-                if (currentLength <= 0)
+                    int currentLength = BinaryPrimitives.ReadInt32LittleEndian(wholeFile.AsSpan((int)offset, 4));
+                    if (currentLength <= 0)
+                    {
+                        continue; // already tombstoned or invalid
+                    }
+
+                    BinaryPrimitives.WriteInt32LittleEndian(marker, -(4 + currentLength));
+                    WriteRecordInPlace(path, offset, marker, ReadOnlySpan<byte>.Empty);
+
+                    pagesToEvict?.Add(ComputePageId(path, offset));
+                }
+            }
+            else
+            {
+                foreach (var offset in offsets)
                 {
-                    continue; // already tombstoned or invalid
+                    if (offset < 0)
+                    {
+                        continue;
+                    }
+
+                    if (RandomAccess.Read(readHandle, lengthBuffer, offset) != 4)
+                    {
+                        continue; // offset at/beyond EOF — not a physical record
+                    }
+
+                    int currentLength = BinaryPrimitives.ReadInt32LittleEndian(lengthBuffer);
+                    if (currentLength <= 0)
+                    {
+                        continue; // already tombstoned or invalid
+                    }
+
+                    BinaryPrimitives.WriteInt32LittleEndian(marker, -(4 + currentLength));
+                    WriteRecordInPlace(path, offset, marker, ReadOnlySpan<byte>.Empty);
+
+                    pagesToEvict?.Add(ComputePageId(path, offset));
                 }
-
-                BinaryPrimitives.WriteInt32LittleEndian(marker, -(4 + currentLength));
-                WriteRecordInPlace(path, offset, marker, ReadOnlySpan<byte>.Empty);
-
-                pagesToEvict?.Add(ComputePageId(path, offset));
             }
         }
         catch (IOException)


### PR DESCRIPTION
## Wat\nTombstoneRecords leest het hele (<=32MB) .dat een keer voor batches van >=64 markers en resolvet elke recordlengte uit het buffer i.p.v. een pread per offset (per-marker pread domineerde de commit in profiling: ~50ms/10K). Per-offset reads blijven fallback voor grotere bestanden/kleine batches.\n\n## Meting (Release, DELETE 10K van ~100K rijen; median van 3)\nSQL ~53K -> ~57K ops/s; Direct ~69K -> ~87K ops/s.\n\n## Validatie\nFull suite (Debug) + Release/CI-filter op alle vier de suites: EXIT=0.