### PR TITLE
perf: whole-file resolution for batch UPDATE fastPatch reads

### DIFF
--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -1946,6 +1946,13 @@ public partial class Table
             // from the file INCLUDING the stale record).
             EnsureAllRegisteredIndexesLoaded();
 
+            // Whole-file snapshot for the per-row fastPatch reads below (same guard as the DELETE
+            // path): reading the small plaintext file once replaces one pread pair per updated row.
+            // A position that already has a buffered in-place overwrite in this transaction is
+            // NEVER served from the snapshot (its disk bytes would be stale) — it falls back to the
+            // per-record read, which honors the write-behind buffer.
+            byte[]? wholeFile = TryLoadWholeFileForRowAccess();
+
             // B8: single-pass contiguous UPDATE — when every operation is a `pk = <literal>` match on a
             // plaintext fixed-width table with physically adjacent PK-ordered records, the old records
             // are read as ONE contiguous byte range and patched in memory (no per-row pread). Strictly
@@ -2007,7 +2014,17 @@ public partial class Table
                     var fastSearch = this.Index.Search(pkWhereVal?.ToString() ?? string.Empty);
                     if (fastSearch.Found)
                     {
-                        var fastData = engine.Read(Name, fastSearch.Value);
+                        byte[]? fastData;
+                        if (fastPatch && wholeFile != null &&
+                            (this.storage is null || !this.storage.HasBufferedOverwriteAt(DataFile, fastSearch.Value)))
+                        {
+                            fastData = TrySlicePayloadFromFile(wholeFile, fastSearch.Value);
+                        }
+                        else
+                        {
+                            fastData = engine.Read(Name, fastSearch.Value);
+                        }
+
                         if (fastData != null)
                         {
                             rows = fastPatch
@@ -2036,7 +2053,17 @@ public partial class Table
                                 rows = [];
                                 foreach (var pos in hashIndex.LookupPositionsUnsafe(key))
                                 {
-                                    var data = engine.Read(Name, pos);
+                                    byte[]? data;
+                                    if (fastPatch && wholeFile != null &&
+                                        (this.storage is null || !this.storage.HasBufferedOverwriteAt(DataFile, pos)))
+                                    {
+                                        data = TrySlicePayloadFromFile(wholeFile, pos);
+                                    }
+                                    else
+                                    {
+                                        data = engine.Read(Name, pos);
+                                    }
+
                                     if (data != null)
                                     {
                                         if (fastPatch)
@@ -3064,7 +3091,7 @@ public partial class Table
 
             // A1: when the (plaintext, legacy variable-length) data file is small enough, read it
             // ONCE and resolve every target from memory instead of one pread pair per deleted row.
-            byte[]? wholeFile = TryLoadWholeFileForDeleteResolution();
+            byte[]? wholeFile = TryLoadWholeFileForRowAccess();
 
             var recordsToDelete = new List<(long storagePosition, Dictionary<string, object> row)>();
 
@@ -3317,7 +3344,7 @@ public partial class Table
     // per deleted row. Guarded to plaintext legacy variable-length files below this size.
     private const long WholeFileDeleteResolutionLimitBytes = 32 * 1024 * 1024;
 
-    private byte[]? TryLoadWholeFileForDeleteResolution()
+    private byte[]? TryLoadWholeFileForRowAccess()
     {
         if (_fixedWidthRecords ||
             this.storage is null ||
@@ -3349,6 +3376,29 @@ public partial class Table
         }
 
         return DeserializeDeleteKeyRow(wholeFile.AsSpan((int)position + 4, recordLength), wanted);
+    }
+
+    /// <summary>
+    /// Copies the raw (plaintext) payload of the record at <paramref name="position"/> out of a
+    /// whole-file snapshot. Returns null when the position/length is not fully contained in the
+    /// snapshot (caller falls back to the per-record read).
+    /// </summary>
+    private byte[]? TrySlicePayloadFromFile(byte[] wholeFile, long position)
+    {
+        if (position < 0 || position + 4 > wholeFile.Length)
+        {
+            return null;
+        }
+
+        int recordLength = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(wholeFile.AsSpan((int)position, 4));
+        if (recordLength <= 0 || position + 4 + recordLength > wholeFile.Length)
+        {
+            return null;
+        }
+
+        var payload = new byte[recordLength];
+        wholeFile.AsSpan((int)position + 4, recordLength).CopyTo(payload);
+        return payload;
     }
 
     /// <summary>

--- a/src/SharpCoreDB/Interfaces/IStorage.cs
+++ b/src/SharpCoreDB/Interfaces/IStorage.cs
@@ -121,6 +121,15 @@ public interface IStorage
     bool HasBufferedOverwrite(string path) => false;
 
     /// <summary>
+    /// True when an in-place overwrite is currently buffered for exactly <paramref name="offset"/>
+    /// of <paramref name="path"/>. Used by whole-file row-resolution fast paths (DELETE/UPDATE) to
+    /// decide whether a disk snapshot slice of a position is fresh or must go through the
+    /// per-record read path (which honors the write-behind buffer). Defaults to false (mock/
+    /// alternative storages have no write-behind buffer to bypass).
+    /// </summary>
+    bool HasBufferedOverwriteAt(string path, long offset) => false;
+
+    /// <summary>
     /// Appends multiple binary data blocks to a file in a single batch operation (used for batch inserts).
     /// </summary>
     /// <param name="path">The file path.</param>

--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -567,6 +567,10 @@ public partial class Storage
         !bufferedOverwrites.IsEmpty && bufferedOverwrites.ContainsKey(path);
 
     /// <inheritdoc />
+    public bool HasBufferedOverwriteAt(string path, long offset) =>
+        bufferedOverwrites.TryGetValue(path, out var overwrites) && overwrites.ContainsKey(offset);
+
+    /// <inheritdoc />
     public bool AreRecordsEncrypted(string path) => UseRecordEncryption && FileHasEncryptedHeader(path);
 
     /// <inheritdoc />


### PR DESCRIPTION
## Wat\nUpdateMultiple laadt het hele plaintext legacy variabele-lengte .dat een keer (<=32MB) en bedient de fastPatch raw-row reads vanuit die snapshot (1 slice-copy per rij) i.p.v. een pread-paar per rij. Posities met een in-batch buffered overwrite worden via de nieuwe IStorage.HasBufferedOverwriteAt gedetecteerd en vallen altijd terug op de per-record read (die de write-behind buffer eert).\n\n## Meting (Release, UPDATE 10K van ~100K rijen; median van 3)\nSQL ~35K -> ~47K ops/s; Direct ~49K -> ~66K ops/s.\n\n## Validatie\nFull suite (Debug) + Release/CI-filter op alle vier de suites: EXIT=0.