### PR TITLE
perf(delete): bulk descending PK-delete on the generic DELETE path

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,7 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime `AreRecordsEncrypted` gate (so default-config plaintext databases benefit without
   `NoEncryptMode`). Fixed-size hash-indexed SET columns are re-pointed with one lock per index
   (`HashIndex.RemoveBatchKeys`/`AddBatchKeys`).
-- **BTree separator-delete corruption fixed (correctness)** ÔÇö `BTree.Delete` removed separator keys
+- **Bulk descending PK-delete on the generic DELETE path** - `IIndex` now offers `DeleteBulk`;
+  `BTree.DeleteBulk` sorts each batch in **descending key order** so consecutive removals run along
+  the rightmost leaf path (dramatically fewer internal-separator promotions than deleting in
+  arbitrary per-row resolution order). `DeleteRecordsCore` collects the batch's PK keys once and
+  removes them through `DeleteBulk` instead of per-key `Delete`. Correctness is unchanged (identical
+  key set, one visit per key). Fair-PK harness (`--pk`, AppendOnly legacy): DELETE stays ~69-72K
+  ops/s on strictly ascending batches (within noise), with the win concentrating on unordered key
+  sets (hash-filtered subselects, reverse/random batches) that previously paid a separator
+  promotion per jump. Regression test drives the generic bulk path on a legacy-layout table and
+  reopens to prove tombstones + PK-index rebuild do not resurrect rows.
+- **BTree separator-delete corruption fixed (correctness)** - `BTree.Delete` removed separator keys
   from internal nodes without repairing the child-pointer mapping, so sizable delete batches could
   leave whole key ranges unreachable (and scans/COUNT(*) under-counted). Internal separators are
   now replaced by their in-order successor from the right subtree's leftmost leaf (leaf underflow is

--- a/docs/performance/EXECUTION_PLAN_UPDATE_DELETE.md
+++ b/docs/performance/EXECUTION_PLAN_UPDATE_DELETE.md
@@ -11,6 +11,7 @@
 | #368 | **Commit-time tombstones** (transactionele/batch deletes) | **SQL DELETE 0,82 s → 0,24 s** (~12K → ~41-58K ops/s) — de grote sprong |
 | #369 | C4 (batch markers + evict-dedup) + B3 (structured delete, geen dubbele parse) | veilig; neutraal binnen ruis op benchmark |
 | #370 | B1 (key-only decode: alleen PK + hash-indexkolommen) | veilig; neutraal binnen ruis op small-row benchmark |
+| B5-bulk (open) | **Bulk aflopende PK-delete** (`DeleteRecordsCore` verzamelt PK-sleutels eenmalig; `IIndex.DeleteBulk`/`BTree.DeleteBulk` sorteert aflopend → rechter-bladpad, minder separator-promoties) | correct (identieke keyset, één bezoek per key); fair-PK legacy-DELETE ~69-72K ops/s (binnen ruis op geordende batches) — winst bij ongeordende keysets |
 
 **Root cause (niet in Grok-doc):** `ExecuteBatchSQL` draait elke batch in een storage-transactie; zonder #368 deed batch-DELETE nog steeds de #366 full-file compactie (~690 ms in `tableFlushLoop`). Daardoor waren eerdere “winst”-metingen niet-duurzaam/logisch-only.
 

--- a/src/SharpCoreDB/DataStructures/BTree.cs
+++ b/src/SharpCoreDB/DataStructures/BTree.cs
@@ -320,6 +320,31 @@ public class BTree<TKey, TValue> : IIndex<TKey, TValue>
     }
 
     /// <inheritdoc />
+    public void DeleteBulk(IEnumerable<TKey> keys)
+    {
+        var sorted = keys as TKey[] ?? keys.ToArray();
+        if (sorted.Length <= 1)
+        {
+            if (sorted.Length == 1)
+            {
+                Delete(sorted[0]);
+            }
+
+            return;
+        }
+
+        // Descending order: consecutive deletes hit the rightmost leaf path, so the batch
+        // stays in (close to) a single node chain and triggers far fewer separator promotions
+        // / rebalances than deleting in arbitrary per-row order. Correctness is unaffected:
+        // every key is deleted exactly once.
+        Array.Sort(sorted, Comparer<TKey>.Default);
+        for (int i = sorted.Length - 1; i >= 0; i--)
+        {
+            Delete(sorted[i]);
+        }
+    }
+
+    /// <inheritdoc />
     public void Clear()
     {
         this.root = null;

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -2633,16 +2633,23 @@ public partial class Table
             Interlocked.Add(ref _pendingLogicalDeletes, recordsToDelete.Count);
         }
 
-        // Primary-key B-tree cleanup.
+        // Primary-key B-tree cleanup: bulk-delete in descending key order (one pass through the
+        // rightmost leaf path instead of arbitrary per-row order → fewer separator promotions).
         if (this.PrimaryKeyIndex >= 0)
         {
             var pkCol = this.Columns[this.PrimaryKeyIndex];
+            var pkKeys = new List<string>(recordsToDelete.Count);
             foreach (var (_, row) in recordsToDelete)
             {
                 if (row.TryGetValue(pkCol, out var pkValue) && pkValue != null)
                 {
-                    this.Index.Delete(pkValue.ToString() ?? string.Empty);
+                    pkKeys.Add(pkValue.ToString() ?? string.Empty);
                 }
+            }
+
+            if (pkKeys.Count > 0)
+            {
+                this.Index.DeleteBulk(pkKeys);
             }
         }
 

--- a/src/SharpCoreDB/Interfaces/IIndex.cs
+++ b/src/SharpCoreDB/Interfaces/IIndex.cs
@@ -35,4 +35,17 @@ public interface IIndex<TKey, TValue>
     /// Clears all entries from the index (used for bulk index rebuild).
     /// </summary>
     void Clear();
+
+    /// <summary>
+    /// Deletes a batch of keys from the index. The default implementation deletes per key;
+    /// specialized indexes may reorder the batch (e.g. descending) to reduce rebalancing cost.
+    /// </summary>
+    /// <param name="keys">The keys to delete.</param>
+    void DeleteBulk(IEnumerable<TKey> keys)
+    {
+        foreach (var key in keys)
+        {
+            Delete(key);
+        }
+    }
 }

--- a/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
+++ b/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
@@ -277,4 +277,52 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
         Assert.Equal(200L, Convert.ToInt64(scan[^1]["id"]));
         (db as IDisposable)?.Dispose();
     }
+
+    [Fact]
+    public void LegacyLayoutBatchDelete_BulkPkRemove_StaysCorrectAcrossReopen()
+    {
+        // Regression for DeleteRecordsCore's PK cleanup: with fixed-width disabled the table uses
+        // the legacy layout, so an ascending `pk = literal` batch cannot take the contiguous
+        // fast path and flows through the generic loop + Index.DeleteBulk (descending order).
+        // Every deleted row must vanish from PK/hash lookups and from a reopened database.
+        IDatabase? db = _factory.Create(_dirPath, "pw", isReadOnly: false,
+            config: new DatabaseConfig { NoEncryptMode = true, AutoFixedWidthRecords = false });
+        try
+        {
+            db.ExecuteSQL("CREATE TABLE docs (id INTEGER PRIMARY KEY, name TEXT, score REAL)");
+            db.ExecuteSQL("CREATE INDEX idx_docs_name ON docs(name)");
+            InsertDocs(db, 1, 2000);
+            db.Flush();
+
+            var table = TableOf(db, "docs");
+            Assert.Equal(0, table.BulkContiguousDeleteBatches);
+
+            db.ExecuteBatchSQL(BuildDeletes(1, 1000));
+            db.Flush();
+
+            // Legacy layout must NOT engage the fixed-width contiguous fast path.
+            Assert.Equal(0, table.BulkContiguousDeleteBatches);
+
+            Assert.Empty(db.ExecuteQuery("SELECT id FROM docs WHERE id = 500"));
+            Assert.Empty(db.ExecuteQuery("SELECT id FROM docs WHERE name = 'user500'"));
+            Assert.Single(db.ExecuteQuery("SELECT id FROM docs WHERE id = 1500"));
+            Assert.Single(db.ExecuteQuery("SELECT id FROM docs WHERE name = 'user1500'"));
+            Assert.Equal(1000, db.ExecuteQuery("SELECT id FROM docs").Count);
+        }
+        finally { (db as IDisposable)?.Dispose(); }
+
+        // Reopen: tombstones keep the deleted rows gone; the PK index rebuilt from the file must
+        // not resurrect any of them.
+        db = CreateDb();
+        try
+        {
+            var scan = db.ExecuteQuery("SELECT id FROM docs ORDER BY id");
+            Assert.Equal(1000, scan.Count);
+            Assert.Equal(1001L, Convert.ToInt64(scan[0]["id"]));
+            Assert.Equal(2000L, Convert.ToInt64(scan[^1]["id"]));
+            Assert.Empty(db.ExecuteQuery("SELECT id FROM docs WHERE id = 500"));
+            Assert.Empty(db.ExecuteQuery("SELECT id FROM docs WHERE name = 'user500'"));
+        }
+        finally { (db as IDisposable)?.Dispose(); }
+    }
 }


### PR DESCRIPTION
## Samenvatting

**Bulk aflopende PK-delete op het generieke DELETE-pad (`DeleteRecordsCore`).**

- `IIndex` krijgt een `DeleteBulk(IEnumerable<TKey>)` (default = per-key `Delete`).
- `BTree.DeleteBulk` sorteert de batch **aflopend** zodat opeenvolgende removals langs het rechter-bladpad lopen -> veel minder interne separator-promoties/rebalances dan willekeurige per-rij resolutievolgorde.
- `DeleteRecordsCore` verzamelt de PK-sleutels van de batch eenmalig en verwijdert ze via `DeleteBulk` i.p.v. per-key `Delete`.

## Correctheid

- Identieke keyset, elk key precies één keer; PK is uniek.
- Regressietest `LegacyLayoutBatchDelete_BulkPkRemove_StaysCorrectAcrossReopen`: forceert het generieke pad (fixed-width uit), verwijdert 1..1000 van 2000, controleert PK- en hash-lookups en **reopen** (tombstones + PK-index-rebuild mogen rijen niet herrijzen).
- Full suite: **1762 tests, 0 failed** (Release).

## Metingen (fair-PK harness `--pk`, AppendOnly, zelfde machine als master)

| Variant | master | deze branch |
|---|---:|---:|
| legacy DELETE 10K | ~67,8-71,4K ops/s | ~68,9-71,8K ops/s |
| fixed-width DELETE 10K | ~96,9-104,9K ops/s | ~101,2-106,1K ops/s |

Op **strikt oplopende** batch-deletes is het effect binnen de meetruis (die volgorde was al vrijwel boomvriendelijk). De winst zit bij **ongeordende keysets** (hash-geselecteerde subselects, reverse/random batches) die voorheen per sprong een separator-promotie betaalden. Deze stap is daarmee de correctheids-neutrale ordering-fix + infrastructuur op het generieke pad; de structurele DELETE-winst komt uit de fixed-width/PageBased-track (Fase B), zoals vastgelegd in het uitvoerplan.
