### PR TITLE
release: 2.0.0.2 (patch) - version bump + full release documentation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <SharpCoreDBVersion>2.0.0.1</SharpCoreDBVersion>
+    <SharpCoreDBVersion>2.0.0.2</SharpCoreDBVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="SharpCoreDB" Version="$(SharpCoreDBVersion)" />

--- a/Examples/CQRS/OrderManagement.CqrsDemo/OrderManagement.CqrsDemo.csproj
+++ b/Examples/CQRS/OrderManagement.CqrsDemo/OrderManagement.CqrsDemo.csproj
@@ -6,7 +6,7 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == '' and Exists('..\..\..\src\SharpCoreDB.CQRS\SharpCoreDB.CQRS.csproj')">true</UseLocalSharpCoreDbSources>
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == ''">false</UseLocalSharpCoreDbSources>

--- a/Examples/EventSourcing/OrderManagement.PersistentDemo/OrderManagement.PersistentDemo.csproj
+++ b/Examples/EventSourcing/OrderManagement.PersistentDemo/OrderManagement.PersistentDemo.csproj
@@ -6,7 +6,7 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == '' and Exists('..\..\..\src\SharpCoreDB\SharpCoreDB.csproj')">true</UseLocalSharpCoreDbSources>
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == ''">false</UseLocalSharpCoreDbSources>

--- a/Examples/EventSourcing/OrderManagement/OrderManagement.csproj
+++ b/Examples/EventSourcing/OrderManagement/OrderManagement.csproj
@@ -6,7 +6,7 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == '' and Exists('..\..\..\src\SharpCoreDB.EventSourcing\SharpCoreDB.EventSourcing.csproj')">true</UseLocalSharpCoreDbSources>
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == ''">false</UseLocalSharpCoreDbSources>

--- a/Examples/FluentMigrator/SharpCoreDB.FluentMigratorDemo/SharpCoreDB.FluentMigratorDemo.csproj
+++ b/Examples/FluentMigrator/SharpCoreDB.FluentMigratorDemo/SharpCoreDB.FluentMigratorDemo.csproj
@@ -6,7 +6,7 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <!-- Set to true to use local source projects instead of NuGet packages -->
     <UseLocalSharpCoreDbSources Condition="'$(UseLocalSharpCoreDbSources)' == '' and Exists('..\..\..\src\SharpCoreDB\SharpCoreDB.csproj')">true</UseLocalSharpCoreDbSources>

--- a/docs/2.0.0.2_WHAT_CHANGED.md
+++ b/docs/2.0.0.2_WHAT_CHANGED.md
@@ -1,0 +1,72 @@
+# SharpCoreDB 2.0.0.2 — What changed & the 2.x engine vs the 1.9.x line
+
+- **Release:** `2.0.0.2` (2026-09-04) — 4-part patch release on the 2.0.0.x line.
+- **Quality gate:** full suite **1770 tests / 0 failed**, CI green on Windows/Ubuntu/macOS +
+  CodeQL + SonarCloud + Server Compatibility Smoke for every merged PR.
+- **Contents:** everything merged since 2.0.0.1 — the perf/hardening batch of PRs #376-#388 —
+  plus the consolidated 2.x-vs-1.9.x overview below.
+- See `docs/CHANGELOG.md` → `[2.0.0.2]` for the detailed change list and
+  `docs/2.0.0.0_WHAT_CHANGED.md` for the full 2.0.0.0 report (this document is the short,
+  forward-looking summary).
+
+## The major steps: 2.x engine vs the 1.9.x engine
+
+### 1. Storage & on-disk format (directory + single-file)
+| Step | 1.9.x | 2.x |
+|---|---|---|
+| Record layout | variable-length length-prefixed rows only | **Fixed-width record layout** (constant stride + out-of-line `.ovf` overflow arena) for columnar PK tables; **default for new PK tables** since B7; per-table flag **persisted in metadata** (authoritative on reopen) with **1.x → 2.0 auto-migration** (opt-in via `FixedWidthRecordLayout`) |
+| DELETE durability | logical delete + full-file rewrite at flush | **Commit-time tombstone markers** (in-place negative length-prefix) → durable in O(delete), no full-file rewrite |
+| In-place writes | only same-length patches, buffered later | **Buffered in-place overwrites flushed per storage page** (C6); markers also batched per page (C5) |
+| Single-file (`.scdb`) | fixed-layout registry, compression bugs | **Format v2** (block registry/FSM/table directory), crash-safe auto-migration, block-level Brotli/GZip/Zstd, envelope encryption, concurrent-write corruption fix (2.0.0.1) |
+
+### 2. Performance engine (the “performance-first” rewrite)
+- **Single-pass contiguous UPDATE/DELETE (B8/B9):** strictly ascending `pk = literal` batches on
+  plaintext fixed-width PK tables are resolved and applied as ONE contiguous range — and since M3
+  the probe verifies the span by decoding each record’s PK slot instead of doing ~10K B-tree
+  searches per batch; PK entries are removed with one descending `DeleteBulk`.
+- **Whole-file DML resolution & key-only decode (B1/W1):** batch UPDATE/DELETE resolve all targets
+  from a single in-memory snapshot decoding only PK/hash columns (no per-row preads).
+- **Legacy variable-length fast path (#380):** strictly-ascending INTEGER-PK batches resolve with a
+  sequential decode pass + early exit (unordered files fall back safely).
+- **Index maintenance:** PK deletes via `IIndex.DeleteBulk` (descending); duplicate-key hash removal
+  no longer quadratic (P5).
+- **Batch INSERT (WP14, 2.0.0.1):** column-ordered `object[]` inserts — no per-row dictionaries.
+- **Structured canonical batch parsing (B3/B9)** and, from 2.0.0.1, in-place field patches (WP11).
+
+### 3. Measurement discipline
+- Fair-PK harness reports **median of 3 per phase** (D1) and gained a **same-window interleaved
+  A/B mode** (`--pk-ab`) so config comparisons are attributable; a **pure-default-config arm**
+  (`--pk-default`) exists to guard the out-of-the-box story.
+
+### 4. Reliability, compatibility & hardening
+- **1.x reads, 2.x writes forward-compat guarantee documented**, including the **downgrade policy**
+  (files with commit-time tombstone markers are not readable by pre-marker binaries) and the
+  recommended read-only-first upgrade order — see `docs/manual/upgrade-and-downgrade.md`.
+- **Default engine selection hardened:** `StorageEngineType.Auto` never silently lands on
+  PageBased (not yet OLTP-ready: ~26K UPDATE ops/s vs ~245K on the fixed-width Columnar path);
+  PageBased remains explicit opt-in.
+- 4-part patch versioning (`n.n.n.n`) since 2.0.0.0.
+
+## Benchmark snapshot (fair-PK, tuned harness config, median-of-3, same machine)
+
+| | SharpCoreDB (Columnar fixed-width) | SQLite | gap |
+|---|---:|---:|---:|
+| UPDATE | ~163-245K ops/s | ~270-315K | ~0.8-1.7x of SQLite (layout/run dependent) |
+| DELETE | ~106-172K ops/s | ~353-420K | ~2.1-3.5x |
+| INSERT | ~125-152K ops/s | ~186-190K | competitive |
+| READ | ~72-110K ops/s | ~95-107K | competitive |
+
+**Honest caveats for this release:**
+- The **default config** (`NoEncryptMode=false`) runs ~1.3-1.6x slower than `NoEncryptMode=true`
+  on ALL phases: `Storage` keeps two encryption layers and the default still pays AES work in the
+  file-level read/page-cache wrappers even though per-record at-rest encryption
+  (`EnableAtRestRecordEncryption`) is off. Root cause quantified with same-window A/B (P3d) and
+  tracked as the next optimization; **FullSync was ruled out** as a cause.
+- These numbers are synthetic ascending-PK batches; other shapes fall back to correct but slower
+  generic paths.
+
+## Upgrade & downgrade
+
+Follow `docs/manual/upgrade-and-downgrade.md`: back up → read-only open → read-write open →
+verify. **Downgrading below the marker-introducing 2.x release is not supported** for databases
+that already contain commit-time tombstone markers.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [2.0.0.2] - 2026-09-04
+
+> Full release notes incl. the 2.x-vs-1.9.x major steps: [`docs/2.0.0.2_WHAT_CHANGED.md`](2.0.0.2_WHAT_CHANGED.md).
+
 ### Hardening
 
 - **NoEncryptMode root cause quantified + explained (P3d)** - definitive 3-rep same-window `--pk-ab`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -145,6 +145,11 @@ guide explaining when SharpCoreDB is fastest.
 
 ## 10. Benchmarks & Performance
 
+- `2.0.0.2_WHAT_CHANGED.md` — ⭐ **release notes (2.0.0.2)**: the 2.x-vs-1.9.x major steps + the
+  2.0.0.2 hardening/perf batch
+- `CHANGELOG.md` — full per-version change log (`[2.0.0.2]`, new `[Unreleased]` on top)
+- `manual/upgrade-and-downgrade.md` — compatibility matrix & downgrade policy
+- `benchmarks/default-config-pk.md` — default-config fair-PK benchmark + NoEncryptMode root cause
 - `manual/performance.md` — ⭐ **Performance Guide**: when SharpCoreDB is fastest + v2.0 results
 - `performance/V2_PERFORMANCE_PLAN.md` — v2.x performance roadmap, root-cause analysis, .NET 11 plan
 - `benchmarks/SHARPCOREDB_COMPARATIVE_BENCHMARKS.md` — comparative report vs SQLite/LiteDB/BLite

--- a/docs/manual/upgrade-and-downgrade.md
+++ b/docs/manual/upgrade-and-downgrade.md
@@ -37,7 +37,10 @@ Recommended upgrade order:
 - Planned (CI): a true **cross-version** job that writes a database with a pinned older commit and
   reads it with `master` (requires an old-binary generator; tracked as follow-up).
 
-## Changelog
+## Changelog & release notes
 
-See `docs/CHANGELOG.md` → `[Unreleased]` → **Hardening** for the marker/downgrade notes that
-accompanied the tombstone work (PRs #367/#368) and this policy document.
+- `docs/CHANGELOG.md` → `[2.0.0.2]` → **Hardening** for the marker/downgrade notes that accompanied
+  the tombstone work (PRs #367/#368) and the 2.0.0.2 hardening batch.
+- `docs/2.0.0.2_WHAT_CHANGED.md` — full release notes incl. the consolidated
+  **2.x-vs-1.9.x major steps** table.
+- `docs/2.0.0.0_WHAT_CHANGED.md` — the original 2.0.0.0 report.

--- a/src/SharpCoreDB.Analytics/SharpCoreDB.Analytics.csproj
+++ b/src/SharpCoreDB.Analytics/SharpCoreDB.Analytics.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
 
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.Analytics</PackageId>

--- a/src/SharpCoreDB.CQRS/SharpCoreDB.CQRS.csproj
+++ b/src/SharpCoreDB.CQRS/SharpCoreDB.CQRS.csproj
@@ -11,7 +11,7 @@
     <NoWarn>$(NoWarn);1591;SA1101;SA1633;SA1309</NoWarn>
 
     <PackageId>SharpCoreDB.CQRS</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.CQRS</Product>

--- a/src/SharpCoreDB.Client.Protocol/SharpCoreDB.Client.Protocol.csproj
+++ b/src/SharpCoreDB.Client.Protocol/SharpCoreDB.Client.Protocol.csproj
@@ -9,7 +9,7 @@
     
     <!-- Assembly info -->
     <AssemblyName>SharpCoreDB.Client.Protocol</AssemblyName>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Description>Client-side protocol implementation for SharpCoreDB (gRPC, binary)</Description>
 
     <!-- NuGet Package Properties -->

--- a/src/SharpCoreDB.Client/SharpCoreDB.Client.csproj
+++ b/src/SharpCoreDB.Client/SharpCoreDB.Client.csproj
@@ -9,7 +9,7 @@
     
     <!-- Assembly info -->
     <AssemblyName>SharpCoreDB.Client</AssemblyName>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Description>.NET client library for SharpCoreDB network server (ADO.NET-like API)</Description>
     
     <!-- NuGet packaging -->

--- a/src/SharpCoreDB.Data.Provider/SharpCoreDB.Data.Provider.csproj
+++ b/src/SharpCoreDB.Data.Provider/SharpCoreDB.Data.Provider.csproj
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</RepositoryUrl>
     <PackageTags>ado.net;database;data-provider;sharpcoredb</PackageTags>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>

--- a/src/SharpCoreDB.Distributed/SharpCoreDB.Distributed.csproj
+++ b/src/SharpCoreDB.Distributed/SharpCoreDB.Distributed.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.Distributed</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Distributed</Product>

--- a/src/SharpCoreDB.EntityFrameworkCore/SharpCoreDB.EntityFrameworkCore.csproj
+++ b/src/SharpCoreDB.EntityFrameworkCore/SharpCoreDB.EntityFrameworkCore.csproj
@@ -8,7 +8,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.EntityFrameworkCore</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.EntityFrameworkCore</Product>

--- a/src/SharpCoreDB.EventSourcing/SharpCoreDB.EventSourcing.csproj
+++ b/src/SharpCoreDB.EventSourcing/SharpCoreDB.EventSourcing.csproj
@@ -11,7 +11,7 @@
     <NoWarn>$(NoWarn);1591;SA1101;SA1633;SA1309</NoWarn>
 
     <PackageId>SharpCoreDB.EventSourcing</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.EventSourcing</Product>

--- a/src/SharpCoreDB.Extensions/SharpCoreDB.Extensions.csproj
+++ b/src/SharpCoreDB.Extensions/SharpCoreDB.Extensions.csproj
@@ -8,7 +8,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.Extensions</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Extensions</Product>

--- a/src/SharpCoreDB.Functional.Dapper/SharpCoreDB.Functional.Dapper.csproj
+++ b/src/SharpCoreDB.Functional.Dapper/SharpCoreDB.Functional.Dapper.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>SharpCoreDB.Functional.Dapper</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Functional.Dapper</Product>

--- a/src/SharpCoreDB.Functional.EntityFrameworkCore/SharpCoreDB.Functional.EntityFrameworkCore.csproj
+++ b/src/SharpCoreDB.Functional.EntityFrameworkCore/SharpCoreDB.Functional.EntityFrameworkCore.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>SharpCoreDB.Functional.EntityFrameworkCore</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Functional.EntityFrameworkCore</Product>

--- a/src/SharpCoreDB.Functional.Linq2DB/SharpCoreDB.Functional.Linq2DB.csproj
+++ b/src/SharpCoreDB.Functional.Linq2DB/SharpCoreDB.Functional.Linq2DB.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>SharpCoreDB.Functional.Linq2DB</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Functional.Linq2DB</Product>

--- a/src/SharpCoreDB.Functional/SharpCoreDB.Functional.csproj
+++ b/src/SharpCoreDB.Functional/SharpCoreDB.Functional.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>SharpCoreDB.Functional</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Functional</Product>

--- a/src/SharpCoreDB.Graph.Advanced/SharpCoreDB.Graph.Advanced.csproj
+++ b/src/SharpCoreDB.Graph.Advanced/SharpCoreDB.Graph.Advanced.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>SharpCoreDB.Graph.Advanced</AssemblyName>
     <RootNamespace>SharpCoreDB.Graph.Advanced</RootNamespace>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <PackageId>SharpCoreDB.Graph.Advanced</PackageId>
     <Authors>MPCoreDeveloper</Authors>
     <Company>MPCoreDeveloper</Company>

--- a/src/SharpCoreDB.Graph/SharpCoreDB.Graph.csproj
+++ b/src/SharpCoreDB.Graph/SharpCoreDB.Graph.csproj
@@ -13,7 +13,7 @@
     <NoWarn>$(NoWarn);1591;SA1101;SA1633;SA1309</NoWarn>
 
     <PackageId>SharpCoreDB.Graph</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Graph</Product>

--- a/src/SharpCoreDB.Identity/SharpCoreDB.Identity.csproj
+++ b/src/SharpCoreDB.Identity/SharpCoreDB.Identity.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <PackageId>SharpCoreDB.Identity</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Identity</Product>

--- a/src/SharpCoreDB.Projections/SharpCoreDB.Projections.csproj
+++ b/src/SharpCoreDB.Projections/SharpCoreDB.Projections.csproj
@@ -11,7 +11,7 @@
     <NoWarn>$(NoWarn);1591;SA1101;SA1633;SA1309</NoWarn>
 
     <PackageId>SharpCoreDB.Projections</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Projections</Product>

--- a/src/SharpCoreDB.Provider.Sync/SharpCoreDB.Provider.Sync.csproj
+++ b/src/SharpCoreDB.Provider.Sync/SharpCoreDB.Provider.Sync.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.Provider.Sync</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Provider.Sync</Product>

--- a/src/SharpCoreDB.Provider.YesSql/SharpCoreDB.Provider.YesSql.csproj
+++ b/src/SharpCoreDB.Provider.YesSql/SharpCoreDB.Provider.YesSql.csproj
@@ -8,7 +8,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.Provider.YesSql</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Provider.YesSql</Product>

--- a/src/SharpCoreDB.Serilog.Sinks/SharpCoreDB.Serilog.Sinks.csproj
+++ b/src/SharpCoreDB.Serilog.Sinks/SharpCoreDB.Serilog.Sinks.csproj
@@ -7,7 +7,7 @@
     
     <!-- NuGet Package Metadata -->
     <PackageId>SharpCoreDB.Serilog.Sinks</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.Serilog.Sinks</Product>

--- a/src/SharpCoreDB.Server.Core/SharpCoreDB.Server.Core.csproj
+++ b/src/SharpCoreDB.Server.Core/SharpCoreDB.Server.Core.csproj
@@ -9,7 +9,7 @@
     
     <!-- Assembly info -->
     <AssemblyName>SharpCoreDB.Server.Core</AssemblyName>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Description>Core server infrastructure for SharpCoreDB network server</Description>
 
     <!-- NuGet Package Properties -->

--- a/src/SharpCoreDB.Server.Protocol/SharpCoreDB.Server.Protocol.csproj
+++ b/src/SharpCoreDB.Server.Protocol/SharpCoreDB.Server.Protocol.csproj
@@ -9,7 +9,7 @@
     
     <!-- Assembly info -->
     <AssemblyName>SharpCoreDB.Server.Protocol</AssemblyName>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Description>Network protocol definitions for SharpCoreDB server (gRPC, binary, HTTP)</Description>
 
     <!-- NuGet Package Properties -->

--- a/src/SharpCoreDB.Server/SharpCoreDB.Server.csproj
+++ b/src/SharpCoreDB.Server/SharpCoreDB.Server.csproj
@@ -19,7 +19,7 @@
     <AssemblyName>sharpcoredb-server</AssemblyName>
     <Product>SharpCoreDB Network Server</Product>
     <Description>SharpCoreDB network database server with gRPC and HTTP support</Description>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>

--- a/src/SharpCoreDB.VectorSearch/SharpCoreDB.VectorSearch.csproj
+++ b/src/SharpCoreDB.VectorSearch/SharpCoreDB.VectorSearch.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB.VectorSearch</PackageId>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB.VectorSearch</Product>

--- a/src/SharpCoreDB/NuGet.README.md
+++ b/src/SharpCoreDB/NuGet.README.md
@@ -1,4 +1,4 @@
-# SharpCoreDB v2.0.0.1 — Performance-First Database Engine
+# SharpCoreDB v2.0.0.2 — Performance-First Database Engine
 
 **High-Performance Embedded AND Networked Database for .NET 10**
 
@@ -9,6 +9,20 @@ SharpCoreDB is a modern, encrypted, file-based database engine with SQL support,
 [![.NET 10](https://img.shields.io/badge/.NET-10-blue.svg)](https://dotnet.microsoft.com/download)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![SonarCloud Quality Gate](https://img.shields.io/sonar/quality_gate/MPCoreDeveloper_SharpCoreDB?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud)](https://sonarcloud.io/dashboard?id=MPCoreDeveloper_SharpCoreDB)
+
+## What's New in 2.0.0.2
+
+- **Commit & overwrite writes are batched per storage page** — tombstone markers (C5) and buffered
+  in-place UPDATE overwrites (C6) are flushed with one write per touched page instead of one/two
+  pwrites per row; the fixed-width contiguous path (B8/B9) no longer does a B-tree search per key
+  (decode verification instead) and removes PK entries with one `DeleteBulk`.
+- **Legacy (variable-length) ascending-PK batches** resolve with one sequential decode pass +
+  early exit; duplicate-key hash removal is no longer quadratic.
+- **Production hardening** — `StorageEngineType.Auto` never silently selects PageBased (not yet
+  OLTP-ready); upgrade/downgrade policy documented with format-compat regression tests; a
+  pure-default-config benchmark arm (`--pk-default`) and a same-window interleaved A/B mode
+  (`--pk-ab`) now guard the numbers.
+- Full report (incl. the 2.x-vs-1.9.x major steps): `docs/2.0.0.2_WHAT_CHANGED.md`.
 
 ## What's New in 2.0.0.1
 
@@ -175,16 +189,16 @@ db.Flush(); // Persist to disk
 ## 📦 Installation
 
 ```bash
-dotnet add package SharpCoreDB --version 2.0.0.1
+dotnet add package SharpCoreDB --version 2.0.0.2
 ```
 
 **Optional companion packages:**
 
 ```bash
-dotnet add package SharpCoreDB.Functional --version 2.0.0.1
-dotnet add package SharpCoreDB.Functional.Dapper --version 2.0.0.1
-dotnet add package SharpCoreDB.Functional.EntityFrameworkCore --version 2.0.0.1
-dotnet add package SharpCoreDB.Graph.Advanced --version 2.0.0.1
+dotnet add package SharpCoreDB.Functional --version 2.0.0.2
+dotnet add package SharpCoreDB.Functional.Dapper --version 2.0.0.2
+dotnet add package SharpCoreDB.Functional.EntityFrameworkCore --version 2.0.0.2
+dotnet add package SharpCoreDB.Graph.Advanced --version 2.0.0.2
 ```
 
 ## 🔄 Upgrading from v1.9
@@ -212,7 +226,7 @@ We welcome contributions! Check the repository for contribution guidelines.
 
 ---
 
-**Latest Version:** 2.0.0.1 (September 2026)  
+**Latest Version:** 2.0.0.2 (September 2026)  
 **Target:** .NET 10 / C# 14  
 **Tests:** 1,700+ (100% passing)  
 **Status:** ✅ Stable — performance-first v2.0.0 release  

--- a/src/SharpCoreDB/SharpCoreDB.csproj
+++ b/src/SharpCoreDB/SharpCoreDB.csproj
@@ -31,9 +31,9 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>SharpCoreDB</PackageId>
-    <Version>2.0.0.1</Version>
-    <AssemblyVersion>2.0.0.1</AssemblyVersion>
-    <FileVersion>2.0.0.1</FileVersion>
+    <Version>2.0.0.2</Version>
+    <AssemblyVersion>2.0.0.2</AssemblyVersion>
+    <FileVersion>2.0.0.2</FileVersion>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>
     <Product>SharpCoreDB</Product>

--- a/src/SharpCoreDB/build/SharpCoreDB.props
+++ b/src/SharpCoreDB/build/SharpCoreDB.props
@@ -2,6 +2,6 @@
 <!-- Copyright (c) 2025 MPCoreDeveloper. Licensed under the MIT License. -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SharpCoreDBVersion>2.0.0.1</SharpCoreDBVersion>
+    <SharpCoreDBVersion>2.0.0.2</SharpCoreDBVersion>
   </PropertyGroup>
 </Project>

--- a/tests/SharpCoreDB.Benchmarks/SharpCoreDB.Benchmarks.csproj
+++ b/tests/SharpCoreDB.Benchmarks/SharpCoreDB.Benchmarks.csproj
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/SharpCoreDB.CQRS.Tests/SharpCoreDB.CQRS.Tests.csproj
+++ b/tests/SharpCoreDB.CQRS.Tests/SharpCoreDB.CQRS.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SharpCoreDB.EntityFrameworkCore.Tests/SharpCoreDB.EntityFrameworkCore.Tests.csproj
+++ b/tests/SharpCoreDB.EntityFrameworkCore.Tests/SharpCoreDB.EntityFrameworkCore.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/SharpCoreDB.EventSourcing.Tests/SharpCoreDB.EventSourcing.Tests.csproj
+++ b/tests/SharpCoreDB.EventSourcing.Tests/SharpCoreDB.EventSourcing.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SharpCoreDB.Identity.Tests/SharpCoreDB.Identity.Tests.csproj
+++ b/tests/SharpCoreDB.Identity.Tests/SharpCoreDB.Identity.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/SharpCoreDB.Profiling/SharpCoreDB.Profiling.csproj
+++ b/tests/SharpCoreDB.Profiling/SharpCoreDB.Profiling.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <PackageId>SharpCoreDB.Profiling</PackageId>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>

--- a/tests/SharpCoreDB.Projections.Tests/SharpCoreDB.Projections.Tests.csproj
+++ b/tests/SharpCoreDB.Projections.Tests/SharpCoreDB.Projections.Tests.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/SharpCoreDB.Tests/SharpCoreDB.Tests.csproj
+++ b/tests/SharpCoreDB.Tests/SharpCoreDB.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/benchmarks/QuickZvecTest/QuickZvecTest.csproj
+++ b/tests/benchmarks/QuickZvecTest/QuickZvecTest.csproj
@@ -6,13 +6,13 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <AssemblyTitle>QuickZvecTest</AssemblyTitle>
     <AssemblyCompany>MPCoreDeveloper</AssemblyCompany>
     <AssemblyCopyright>Copyright (c) 2026 MPCoreDeveloper and GitHub Copilot. All rights reserved.</AssemblyCopyright>
-    <AssemblyVersion>2.0.0.1</AssemblyVersion>
-    <FileVersion>2.0.0.1</FileVersion>
+    <AssemblyVersion>2.0.0.2</AssemblyVersion>
+    <FileVersion>2.0.0.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/benchmarks/SharpCoreDB.Benchmarks.Comparative/SharpCoreDB.Benchmarks.Comparative.csproj
+++ b/tests/benchmarks/SharpCoreDB.Benchmarks.Comparative/SharpCoreDB.Benchmarks.Comparative.csproj
@@ -6,7 +6,7 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <AssemblyTitle>SharpCoreDB.Benchmarks.Comparative</AssemblyTitle>
     <AssemblyCompany>MPCoreDeveloper</AssemblyCompany>

--- a/tests/benchmarks/SharpCoreDB.Benchmarks/SharpCoreDB.Benchmarks.csproj
+++ b/tests/benchmarks/SharpCoreDB.Benchmarks/SharpCoreDB.Benchmarks.csproj
@@ -6,14 +6,14 @@
     <LangVersion>14.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SharpCoreDB.Benchmarks</AssemblyTitle>
     <AssemblyCompany>MPCoreDeveloper</AssemblyCompany>
     <AssemblyCopyright>Copyright (c) 2026 MPCoreDeveloper and GitHub Copilot. All rights reserved.</AssemblyCopyright>
-    <AssemblyVersion>2.0.0.1</AssemblyVersion>
-    <FileVersion>2.0.0.1</FileVersion>
+    <AssemblyVersion>2.0.0.2</AssemblyVersion>
+    <FileVersion>2.0.0.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/benchmarks/SharpCoreDB.CQRS.Benchmarks/SharpCoreDB.CQRS.Benchmarks.csproj
+++ b/tests/benchmarks/SharpCoreDB.CQRS.Benchmarks/SharpCoreDB.CQRS.Benchmarks.csproj
@@ -9,7 +9,7 @@
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <AssemblyTitle>SharpCoreDB.CQRS.Benchmarks</AssemblyTitle>
     <AssemblyCompany>MPCoreDeveloper</AssemblyCompany>
     <AssemblyCopyright>Copyright (c) 2026 MPCoreDeveloper and GitHub Copilot. All rights reserved.</AssemblyCopyright>

--- a/tools/SharpCoreDB.DebugBenchmark/SharpCoreDB.DebugBenchmark.csproj
+++ b/tools/SharpCoreDB.DebugBenchmark/SharpCoreDB.DebugBenchmark.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>14.0</LangVersion>
     <IsPackable>false</IsPackable>
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <PackageId>SharpCoreDB.DebugBenchmark</PackageId>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>

--- a/tools/SharpCoreDB.Demo/SharpCoreDB.Demo.csproj
+++ b/tools/SharpCoreDB.Demo/SharpCoreDB.Demo.csproj
@@ -11,7 +11,7 @@
     <!-- This is a demo app, not a NuGet package -->
     <IsPackable>false</IsPackable>
     
-    <Version>2.0.0.1</Version>
+    <Version>2.0.0.2</Version>
     <PackageId>SharpCoreDB.Demo</PackageId>
     <Authors>MPCoreDeveloper</Authors>
     <Company>SharpCoreDB</Company>


### PR DESCRIPTION
## Release 2.0.0.2 — versie-bump + volledige releasedocumentatie

### Versie
Alle projecten, tests, tools, examples en `Directory.Packages.props` zijn naar
**`2.0.0.2`** gezet (4-delige patch op de 2.0.0.x-lijn).

### Documentatie (nieuw/bijgewerkt)
- **`docs/2.0.0.2_WHAT_CHANGED.md`** (nieuw) — release-notities met de **grote stappen van de
  2.x-engine t.o.v. de 1.9.x-engine**, geconsolideerd in één overzicht:
  1. **Opslag/format** — fixed-width record-layout default voor nieuwe columnar PK-tabellen
     (persisted per-tabel flag + 1.x→2.0 auto-migratie opt-in), commit-time tombstone-markers,
     page-gebatchete marker/overwrite writes, single-file format v2 + compressie/encryptie.
  2. **Performance-engine** — single-pass contiguous UPDATE/DELETE (B8/B9), probe zonder per-key
     B-tree searches (M3), whole-file DML-resolutie, `DeleteBulk`/hash bulk-remove, batch-INSERT
     object[] (WP14), in-place patches (WP11).
  3. **Meetdiscipline** — median-of-3 harness, `--pk-default`, same-window `--pk-ab`.
  4. **Betrouwbaarheid/hardening** — downgrade-policy gedocumenteerd, default-engine-selectie
     nooit op PageBased, single-file concurrency-fix (2.0.0.1), 4-delige versienummers.
  Plus de **eerlijke default-config caveats** (NoEncryptMode file-level wrapper ~1.3-1.6x) en een
  benchmark-tabel.
- **`docs/CHANGELOG.md`** — `[Unreleased]` (perf/hardening-batch #376-#388 + eerder unreleased)
  verplaatst naar `[2.0.0.2] - 2026-09-04`; nieuw leeg `[Unreleased]` bovenop + link naar de
  release-notities.
- **`src/SharpCoreDB/NuGet.README.md`** — titel v2.0.0.2 + “What’s New in 2.0.0.2”-sectie +
  install/latest bijgewerkt.
- **`docs/INDEX.md`** en **`docs/manual/upgrade-and-downgrade.md`** linken de nieuwe
  release-notities.

### Validatie
- Build groen (alle csproj’s op 2.0.0.2, geen oude versie-tokens meer).
- Full suite: **1770 tests, 0 failed**.
