### PR TITLE
docs: publish-facing 2.0.0.2 updates (README + NuGet info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Use it when you need:
 > than SQLite** on `GROUP BY` SUM, and the engine is **Native AOT-ready**. Full results:
 > [docs/manual/performance.md](docs/manual/performance.md).
 
+> **Latest release: 2.0.0.2 (2026-09-04)** — the 2.x engine line: fixed-width record layout is the
+> default for new PK tables, UPDATE/DELETE run in-place with commit-time tombstones, and a reopen
+> data-integrity hardening batch closed silent-data-loss edge cases (empty-value overflow reload,
+> single-file fixed-width arena markers, legacy 1.x delete-after-update purge).
+>
+> **Performance (fair-PK, median-of-3, tuned harness):** UPDATE **~163–245K ops/s**, DELETE
+> **~106–172K ops/s**, INSERT **~125–152K ops/s**, READ **~72–110K ops/s** (SQLite reference:
+> UPDATE ~270–315K, DELETE ~353–420K, INSERT ~186–190K). Honest default-config caveat: the pure
+> default config runs ~1.3–1.6x slower because the file-level wrapper still pays AES work while
+> per-record at-rest encryption is off (`NoEncryptMode` root cause, P3d). Full report:
+> [`docs/2.0.0.2_WHAT_CHANGED.md`](docs/2.0.0.2_WHAT_CHANGED.md) and
+> [`docs/benchmarks/default-config-pk.md`](docs/benchmarks/default-config-pk.md).
+
 > Full documentation: **`docs/INDEX.md`** · Manual: **`docs/manual/README.md`** · Performance: **`docs/manual/performance.md`**
 
 ---
@@ -106,7 +119,7 @@ Track the v2.x plan: **[`docs/performance/V2_PERFORMANCE_PLAN.md`](docs/performa
 ### 1) Embedded mode
 
 ```bash
-dotnet add package SharpCoreDB --version 2.0.0
+dotnet add package SharpCoreDB --version 2.0.0.2
 ```
 
 ```csharp
@@ -143,8 +156,8 @@ gRPC endpoint: `https://localhost:5001`
 Install client/server packages:
 
 ```bash
-dotnet add package SharpCoreDB.Server --version 2.0.0
-dotnet add package SharpCoreDB.Client --version 2.0.0
+dotnet add package SharpCoreDB.Server --version 2.0.0.2
+dotnet add package SharpCoreDB.Client --version 2.0.0.2
 ```
 
 
@@ -160,36 +173,36 @@ dotnet add package SharpCoreDB.Client --version 2.0.0
 
 ---
 
-## Available NuGet packages (v2.0.0)
+## Available NuGet packages (v2.0.0.2)
 
 ```bash
 # Core
-dotnet add package SharpCoreDB --version 2.0.0
+dotnet add package SharpCoreDB --version 2.0.0.2
 
 # Server/client
-dotnet add package SharpCoreDB.Server --version 2.0.0
-dotnet add package SharpCoreDB.Client --version 2.0.0
+dotnet add package SharpCoreDB.Server --version 2.0.0.2
+dotnet add package SharpCoreDB.Client --version 2.0.0.2
 
 # Engines and extensions
-dotnet add package SharpCoreDB.Analytics --version 2.0.0
-dotnet add package SharpCoreDB.VectorSearch --version 2.0.0
-dotnet add package SharpCoreDB.Graph --version 2.0.0
-dotnet add package SharpCoreDB.Graph.Advanced --version 2.0.0
-dotnet add package SharpCoreDB.Distributed --version 2.0.0
-dotnet add package SharpCoreDB.Provider.Sync --version 2.0.0
-dotnet add package SharpCoreDB.EntityFrameworkCore --version 2.0.0
-dotnet add package SharpCoreDB.Extensions --version 2.0.0
+dotnet add package SharpCoreDB.Analytics --version 2.0.0.2
+dotnet add package SharpCoreDB.VectorSearch --version 2.0.0.2
+dotnet add package SharpCoreDB.Graph --version 2.0.0.2
+dotnet add package SharpCoreDB.Graph.Advanced --version 2.0.0.2
+dotnet add package SharpCoreDB.Distributed --version 2.0.0.2
+dotnet add package SharpCoreDB.Provider.Sync --version 2.0.0.2
+dotnet add package SharpCoreDB.EntityFrameworkCore --version 2.0.0.2
+dotnet add package SharpCoreDB.Extensions --version 2.0.0.2
 
 # Optional architecture packages
-dotnet add package SharpCoreDB.EventSourcing --version 2.0.0
-dotnet add package SharpCoreDB.Projections --version 2.0.0
-dotnet add package SharpCoreDB.CQRS --version 2.0.0
+dotnet add package SharpCoreDB.EventSourcing --version 2.0.0.2
+dotnet add package SharpCoreDB.Projections --version 2.0.0.2
+dotnet add package SharpCoreDB.CQRS --version 2.0.0.2
 
 # Optional functional adapters
-dotnet add package SharpCoreDB.Functional --version 2.0.0
-dotnet add package SharpCoreDB.Functional.Dapper --version 2.0.0
-dotnet add package SharpCoreDB.Functional.EntityFrameworkCore --version 2.0.0
-dotnet add package SharpCoreDB.Functional.Linq2DB --version 2.0.0
+dotnet add package SharpCoreDB.Functional --version 2.0.0.2
+dotnet add package SharpCoreDB.Functional.Dapper --version 2.0.0.2
+dotnet add package SharpCoreDB.Functional.EntityFrameworkCore --version 2.0.0.2
+dotnet add package SharpCoreDB.Functional.Linq2DB --version 2.0.0.2
 ```
 
 ---

--- a/src/SharpCoreDB.Analytics/NuGet.README.md
+++ b/src/SharpCoreDB.Analytics/NuGet.README.md
@@ -3,7 +3,7 @@
 This package is part of SharpCoreDB, a high-performance embedded database for .NET 10.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.
@@ -16,13 +16,13 @@ For full documentation, see: https://github.com/MPCoreDeveloper/SharpCoreDB/blob
 
 See the main repository for usage examples.
 
-# SharpCoreDB.Analytics v1.9.5
+# SharpCoreDB.Analytics v2.0.0.2
 
 **Advanced Analytics Engine for SharpCoreDB**
 
 Unlock enterprise-grade analytics with 100+ aggregate functions, window functions, and statistical analysis tools - **150-680x faster than SQLite**.
 
-## ✨ What's New in v1.9.5
+## ✨ What's New in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ Inherits metadata improvements from SharpCoreDB v1.9.5
 - ✅ Phase 9 complete: 100+ aggregate and window functions

--- a/src/SharpCoreDB.Analytics/SharpCoreDB.Analytics.csproj
+++ b/src/SharpCoreDB.Analytics/SharpCoreDB.Analytics.csproj
@@ -13,7 +13,7 @@
     <Product>SharpCoreDB.Analytics</Product>
     <Description>Analytics extensions for SharpCoreDB: aggregates, window functions, SIMD-accelerated analytics, and time-series helpers for .NET 10.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>analytics;aggregates;window-functions;statistics;timeseries;database;sharpcoredb;net10;csharp14</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.CQRS/NuGet.README.md
+++ b/src/SharpCoreDB.CQRS/NuGet.README.md
@@ -1,9 +1,9 @@
-# SharpCoreDB.CQRS v1.9.5
+# SharpCoreDB.CQRS v2.0.0.2
 
 CQRS and outbox primitives for `SharpCoreDB`.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.CQRS/SharpCoreDB.CQRS.csproj
+++ b/src/SharpCoreDB.CQRS/SharpCoreDB.CQRS.csproj
@@ -24,7 +24,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Client.Protocol/SharpCoreDB.Client.Protocol.csproj
+++ b/src/SharpCoreDB.Client.Protocol/SharpCoreDB.Client.Protocol.csproj
@@ -26,7 +26,7 @@
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Client/NuGet.README.md
+++ b/src/SharpCoreDB.Client/NuGet.README.md
@@ -1,9 +1,9 @@
-# SharpCoreDB.Client v1.9.5
+# SharpCoreDB.Client v2.0.0.2
 
 .NET client library for `SharpCoreDB.Server`.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Data.Provider/NuGet.README.md
+++ b/src/SharpCoreDB.Data.Provider/NuGet.README.md
@@ -1,11 +1,11 @@
-# SharpCoreDB.Data.Provider v1.9.5
+# SharpCoreDB.Data.Provider v2.0.0.2
 
 **ADO.NET Data Provider for SharpCoreDB**
 
 Complete ADO.NET provider enabling standard database connectivity patterns with SharpCoreDB's encryption and performance.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Data.Provider/SharpCoreDB.Data.Provider.csproj
+++ b/src/SharpCoreDB.Data.Provider/SharpCoreDB.Data.Provider.csproj
@@ -24,7 +24,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>SharpCoreDB.Data.Provider</PackageId>
     <Description>Data provider layer for SharpCoreDB on .NET 10.</Description>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
 
     <!-- Visual Studio: Enable "Pack" command to create multi-RID package -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/src/SharpCoreDB.Distributed/NuGet.README.md
+++ b/src/SharpCoreDB.Distributed/NuGet.README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.
@@ -121,13 +121,13 @@ await distributedDb.ExecuteAsync(
 
 MIT License - see [LICENSE](https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/LICENSE) for details.
 
-# SharpCoreDB.Distributed v1.9.5
+# SharpCoreDB.Distributed v2.0.0.2
 
 **Enterprise Distributed Database Features**
 
 Multi-master replication, distributed transactions, and automatic sharding - Phase 10 complete with sub-100ms replication latency.
 
-## ✨ What's New in v1.9.5
+## ✨ What's New in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ Phase 10.2: Multi-master replication with vector clocks
 - ✅ Phase 10.3: Distributed transactions with 2PC protocol

--- a/src/SharpCoreDB.Distributed/SharpCoreDB.Distributed.csproj
+++ b/src/SharpCoreDB.Distributed/SharpCoreDB.Distributed.csproj
@@ -28,7 +28,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.EntityFrameworkCore/NuGet.README.md
+++ b/src/SharpCoreDB.EntityFrameworkCore/NuGet.README.md
@@ -1,4 +1,4 @@
-# SharpCoreDB.EntityFrameworkCore v1.9.1
+# SharpCoreDB.EntityFrameworkCore v2.0.0.2
 
 **Entity Framework Core Provider for SharpCoreDB**
 
@@ -11,7 +11,7 @@ Full EF Core integration with SharpCoreDB's encryption and performance for moder
 - Root cause was missing Guid normalization during INSERT parameter binding (now aligned with DateTime handling).
 - The recommended pattern now works reliably with Guid primary keys and foreign keys.
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ Fixed EF Core materialization for aliased and quoted SELECT columns by normalizing DataReader column names and fallback value resolution.
 - ✅ Added targeted regression tests for aliased and qualified column lookup behavior.

--- a/src/SharpCoreDB.EntityFrameworkCore/SharpCoreDB.EntityFrameworkCore.csproj
+++ b/src/SharpCoreDB.EntityFrameworkCore/SharpCoreDB.EntityFrameworkCore.csproj
@@ -14,7 +14,7 @@
     <Product>SharpCoreDB.EntityFrameworkCore</Product>
     <Description>Entity Framework Core provider for SharpCoreDB encrypted database engine. Built for .NET 10 with C# 14. Supports Windows, Linux, macOS, Android, iOS, and IoT/embedded devices with platform-specific optimizations. Compatible with SharpCoreDB 1.7.1.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;entityframeworkcore;efcore;database;encryption;net10;csharp14;android;ios;mobile;iot;arm64;x64</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.EventSourcing/NuGet.README.md
+++ b/src/SharpCoreDB.EventSourcing/NuGet.README.md
@@ -1,9 +1,9 @@
-# SharpCoreDB.EventSourcing v1.9.5
+# SharpCoreDB.EventSourcing v2.0.0.2
 
 Event store primitives for `SharpCoreDB`.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.EventSourcing/SharpCoreDB.EventSourcing.csproj
+++ b/src/SharpCoreDB.EventSourcing/SharpCoreDB.EventSourcing.csproj
@@ -24,7 +24,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Extensions/NuGet.README.md
+++ b/src/SharpCoreDB.Extensions/NuGet.README.md
@@ -3,7 +3,7 @@
 This package is part of SharpCoreDB, a high-performance embedded database for .NET 10.
 
 
-## What's New in v1.9.5
+## What's New in v1.9.5 (archived; current release 2.0.0.2)
 
 - **FluentMigrator alignment**: `AddSharpCoreDBFluentMigrator()` now defaults both generator and processor to SQLite-compatible mode.
 - Inherits all v1.9.5 engine improvements (Auto-ROWID, GRAPH_RAG, SIMD optimization, Logging.Abstractions 10.0.7).
@@ -17,13 +17,13 @@ For full documentation, see: https://github.com/MPCoreDeveloper/SharpCoreDB/blob
 
 See the main repository for usage examples.
 
-# SharpCoreDB.Extensions v1.9.5
+# SharpCoreDB.Extensions v2.0.0.2
 
 **Dapper Integration and ASP.NET Core Extensions**
 
 Dapper ORM integration and ASP.NET Core health check extensions for SharpCoreDB.
 
-## ✨ What's New in v1.9.5
+## ✨ What's New in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **FluentMigrator alignment**: `AddSharpCoreDBFluentMigrator()` defaults generator and processor to SQLite-compatible mode
 - ✅ Inherits v1.9.5 engine improvements (Auto-ROWID, GRAPH_RAG SQL, SIMD optimization)

--- a/src/SharpCoreDB.Extensions/SharpCoreDB.Extensions.csproj
+++ b/src/SharpCoreDB.Extensions/SharpCoreDB.Extensions.csproj
@@ -14,7 +14,7 @@
     <Product>SharpCoreDB.Extensions</Product>
     <Description>Extensions for SharpCoreDB including Dapper integration and ASP.NET Core health checks. Built for .NET 10 with C# 14. Supports Windows, Linux, macOS, Android, iOS, and IoT/embedded devices with platform-specific optimizations.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;database;dapper;healthchecks;extensions;net10;csharp14;android;ios;mobile;iot;arm64;x64</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.Functional.Dapper/SharpCoreDB.Functional.Dapper.csproj
+++ b/src/SharpCoreDB.Functional.Dapper/SharpCoreDB.Functional.Dapper.csproj
@@ -13,7 +13,7 @@
     <Product>SharpCoreDB.Functional.Dapper</Product>
     <Description>Dapper adapter for SharpCoreDB.Functional with zero-dependency Option/Fin APIs and fluent functional composition for .NET 10 and C# 14.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;functional;dapper;option;fin;net10;csharp14</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.Functional.EntityFrameworkCore/SharpCoreDB.Functional.EntityFrameworkCore.csproj
+++ b/src/SharpCoreDB.Functional.EntityFrameworkCore/SharpCoreDB.Functional.EntityFrameworkCore.csproj
@@ -13,7 +13,7 @@
     <Product>SharpCoreDB.Functional.EntityFrameworkCore</Product>
     <Description>Entity Framework Core adapter for SharpCoreDB.Functional with zero-dependency Option/Fin APIs and fluent functional composition for .NET 10 and C# 14.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;functional;entityframeworkcore;efcore;option;fin;net10;csharp14</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.Functional.Linq2DB/SharpCoreDB.Functional.Linq2DB.csproj
+++ b/src/SharpCoreDB.Functional.Linq2DB/SharpCoreDB.Functional.Linq2DB.csproj
@@ -13,7 +13,7 @@
     <Product>SharpCoreDB.Functional.Linq2DB</Product>
     <Description>Production-ready linq2db adapter for SharpCoreDB.Functional. Zero-dependency Option/Fin/Seq APIs, compile-time LINQ safety, BulkCopy batching, full type mappings (ULID/GUID), and low-overhead queries. Perfect for AI/agentic and GraphRAG workloads on .NET 10 / C# 14.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;functional;linq2db;linq;option;fin;net10;csharp14;aot</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.Functional/SharpCoreDB.Functional.csproj
+++ b/src/SharpCoreDB.Functional/SharpCoreDB.Functional.csproj
@@ -13,7 +13,7 @@
     <Product>SharpCoreDB.Functional</Product>
     <Description>Functional facade for SharpCoreDB with zero-dependency Option, Fin, Seq, and Unit types, fluent composition, and low-allocation wrappers for .NET 10 and C# 14.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;functional;option;result;fin;monad;net10;csharp14</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.Graph.Advanced/NuGet.README.md
+++ b/src/SharpCoreDB.Graph.Advanced/NuGet.README.md
@@ -1,9 +1,9 @@
-# SharpCoreDB.Graph.Advanced v1.9.5
+# SharpCoreDB.Graph.Advanced v2.0.0.2
 
 Advanced graph analytics and GraphRAG package for `SharpCoreDB`.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Graph/NuGet.README.md
+++ b/src/SharpCoreDB.Graph/NuGet.README.md
@@ -3,7 +3,7 @@
 This package is part of SharpCoreDB, a high-performance embedded database for .NET 10.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.
@@ -16,13 +16,13 @@ For full documentation, see: https://github.com/MPCoreDeveloper/SharpCoreDB/blob
 
 See the main repository for usage examples.
 
-# SharpCoreDB.Graph v1.9.5
+# SharpCoreDB.Graph v2.0.0.2
 
 **Lightweight Graph Traversal Engine**
 
 A* pathfinding and graph algorithms **30-50% faster than alternatives** with pure managed C# 14 code.
 
-## ✨ What's New in v1.9.5
+## ✨ What's New in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ Inherits metadata improvements from SharpCoreDB v1.9.5
 - ✅ Phase 6 complete: A* pathfinding with 30-50% improvement

--- a/src/SharpCoreDB.Graph/SharpCoreDB.Graph.csproj
+++ b/src/SharpCoreDB.Graph/SharpCoreDB.Graph.csproj
@@ -26,7 +26,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Projections/NuGet.README.md
+++ b/src/SharpCoreDB.Projections/NuGet.README.md
@@ -1,9 +1,9 @@
-# SharpCoreDB.Projections v1.9.5
+# SharpCoreDB.Projections v2.0.0.2
 
 Projection primitives for `SharpCoreDB.EventSourcing`.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Projections/SharpCoreDB.Projections.csproj
+++ b/src/SharpCoreDB.Projections/SharpCoreDB.Projections.csproj
@@ -24,7 +24,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Provider.Sync/NuGet.README.md
+++ b/src/SharpCoreDB.Provider.Sync/NuGet.README.md
@@ -1,11 +1,11 @@
-# SharpCoreDB.Provider.Sync v1.9.5
+# SharpCoreDB.Provider.Sync v2.0.0.2
 
 **Dotmim.Sync Provider for SharpCoreDB**
 
 Bidirectional synchronization with SQL Server, PostgreSQL, MySQL, and SQLite - Phase 10.1 complete with enterprise conflict resolution.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Provider.YesSql/NuGet.README.md
+++ b/src/SharpCoreDB.Provider.YesSql/NuGet.README.md
@@ -1,11 +1,11 @@
-# SharpCoreDB.Provider.YesSql v1.9.5
+# SharpCoreDB.Provider.YesSql v2.0.0.2
 
 **YesSql Provider for SharpCoreDB**
 
 YesSql ORM integration with SharpCoreDB's encryption and performance for document-oriented patterns.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Provider.YesSql/SharpCoreDB.Provider.YesSql.csproj
+++ b/src/SharpCoreDB.Provider.YesSql/SharpCoreDB.Provider.YesSql.csproj
@@ -14,7 +14,7 @@
     <Product>SharpCoreDB.Provider.YesSql</Product>
     <Description>YesSql provider for SharpCoreDB encrypted database engine. Built for .NET 10 with C# 14. Supports Windows, Linux, macOS, Android, iOS, and IoT/embedded devices with platform-specific optimizations.</Description>
     <Copyright>Copyright (c) 2026 MPCoreDeveloper</Copyright>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
     <PackageTags>sharpcoredb;yessql;database;orm;net10;csharp14;android;ios;mobile;iot;arm64;x64</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/MPCoreDeveloper/SharpCoreDB</PackageProjectUrl>

--- a/src/SharpCoreDB.Serilog.Sinks/NuGet.README.md
+++ b/src/SharpCoreDB.Serilog.Sinks/NuGet.README.md
@@ -1,11 +1,11 @@
-# SharpCoreDB.Serilog.Sinks v1.9.5
+# SharpCoreDB.Serilog.Sinks v2.0.0.2
 
 **Serilog Sink for SharpCoreDB**
 
 Efficient batch logging to SharpCoreDB with AES-256-GCM encryption and AppendOnly storage for maximum write speed.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.Serilog.Sinks/SharpCoreDB.Serilog.Sinks.csproj
+++ b/src/SharpCoreDB.Serilog.Sinks/SharpCoreDB.Serilog.Sinks.csproj
@@ -24,7 +24,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Server.Core/SharpCoreDB.Server.Core.csproj
+++ b/src/SharpCoreDB.Server.Core/SharpCoreDB.Server.Core.csproj
@@ -26,7 +26,7 @@
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Server.Protocol/SharpCoreDB.Server.Protocol.csproj
+++ b/src/SharpCoreDB.Server.Protocol/SharpCoreDB.Server.Protocol.csproj
@@ -26,7 +26,7 @@
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB.Server/NuGet.README.md
+++ b/src/SharpCoreDB.Server/NuGet.README.md
@@ -1,9 +1,9 @@
-# SharpCoreDB.Server v1.9.5
+# SharpCoreDB.Server v2.0.0.2
 
 Network database server package for `SharpCoreDB`.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.VectorSearch/NuGet.README.md
+++ b/src/SharpCoreDB.VectorSearch/NuGet.README.md
@@ -1,11 +1,11 @@
-# SharpCoreDB.VectorSearch v1.9.5
+# SharpCoreDB.VectorSearch v2.0.0.2
 
 **SIMD-Accelerated Vector Similarity Search**
 
 Semantic search and similarity matching **50-100x faster than SQLite** using HNSW indexing and SIMD acceleration.
 
 
-## Patch updates in v1.9.5
+## Patch updates in v1.9.5 (archived; current release 2.0.0.2)
 
 - ✅ **Parameterized query binding fixed** (Issue #336): named-parameter binding is token-aware, so parameter names that are prefixes of others (e.g. `@t` vs `@tid`) no longer corrupt the SQL.
 - ✅ **Server parameter pass-through fixed** (Issue #337): `request.Parameters` are forwarded on gRPC, the binary (PostgreSQL) protocol and WebSocket.

--- a/src/SharpCoreDB.VectorSearch/SharpCoreDB.VectorSearch.csproj
+++ b/src/SharpCoreDB.VectorSearch/SharpCoreDB.VectorSearch.csproj
@@ -28,7 +28,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIcon>SharpCoreDB.jpg</PackageIcon>
     <PackageReadmeFile>NuGet.README.md</PackageReadmeFile>
-    <PackageReleaseNotes>v1.9.6: Fixes the critical WHERE IN (...) regression (#339) that silently returned ALL rows: IN / NOT IN are now evaluated correctly for literal and parameterized lists across single-file and directory mode, and single-file parameterized queries normalize @-prefixed parameter names. Includes all v1.9.5 fixes (token-aware parameter binding resolving @t/@tid collisions, server parameter pass-through, standards-compliant ULID encoding, legacy UI removal, English-only documentation, updated dependencies).</PackageReleaseNotes>
+    <PackageReleaseNotes>v2.0.0.2 (2026-09-04): 2.x performance-first engine line - fixed-width record default for new PK tables, in-place UPDATE/DELETE with commit-time tombstones, and reopen data-integrity hardening (empty-value overflow reload, single-file fixed-width arena markers, legacy delete purge). Full details: https://github.com/MPCoreDeveloper/SharpCoreDB/blob/master/docs/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharpCoreDB/NuGet.README.md
+++ b/src/SharpCoreDB/NuGet.README.md
@@ -28,6 +28,10 @@ SharpCoreDB is a modern, encrypted, file-based database engine with SQL support,
   (1.x-upgrade) variable-length tables purge older row versions when a row is deleted, so deleted
   rows can no longer resurrect after a reopen. Locked in by the new `ReopenRoundTripMatrixTests`
   and outbox/CQRS integration coverage.
+- **Measured performance (fair-PK, median-of-3, tuned harness):** UPDATE **~163–245K ops/s**,
+  DELETE **~106–172K ops/s**, INSERT **~125–152K ops/s**, READ **~72–110K ops/s**. Honest
+  default-config caveat: the pure default config runs ~1.3–1.6x slower (file-level wrapper still
+  pays AES work while per-record at-rest encryption is off — `NoEncryptMode` root cause, P3d).
 - Full report (incl. the 2.x-vs-1.9.x major steps): `docs/2.0.0.2_WHAT_CHANGED.md`.
 
 ## What's New in 2.0.0.1


### PR DESCRIPTION
Publish-facing content aligned to the 2.0.0.2 release:
- Root README: latest-release block for 2.0.0.2 with fair-PK performance results + default-config caveat; all dotnet add package snippets and the package section header pinned to 2.0.0.2.
- Core NuGet.README: measured performance bullet added to What is New in 2.0.0.2.
- Per-package NuGet.README files: package titles bumped to v2.0.0.2; v1.9.x What is New sections labelled archived (current release 2.0.0.2).
- All 20 packable csproj files: PackageReleaseNotes replaced with a uniform v2.0.0.2 note (previously stale v1.9.6 / v2.0.0 text shown on NuGet.org).