### PR TITLE
sonar: fix mechanical and new-code issues (batch 1)

### DIFF
--- a/src/SharpCoreDB/DataStructures/OverflowArena.cs
+++ b/src/SharpCoreDB/DataStructures/OverflowArena.cs
@@ -121,34 +121,29 @@ public sealed class OverflowArena : IDisposable, IOverflowArena
     private bool TryReuseFreeBlock(byte[] payload, out long offset)
     {
         offset = 0;
-        if (!_freeByLength.TryGetValue(payload.Length, out var offsets))
+        if (!_freeByLength.TryGetValue(payload.Length, out var offsets) || offsets.Count == 0)
         {
             return false;
         }
 
-        while (offsets.Count > 0)
+        offset = offsets[^1];
+        offsets.RemoveAt(offsets.Count - 1);
+
+        if (_storage.OverwriteRecordAt(_filePath, offset, payload))
         {
-            offset = offsets[^1];
-            offsets.RemoveAt(offsets.Count - 1);
-
-            if (_storage.OverwriteRecordAt(_filePath, offset, payload))
+            if (offsets.Count == 0)
             {
-                if (offsets.Count == 0)
-                {
-                    _freeByLength.Remove(payload.Length);
-                }
-
-                _cache[offset] = payload;
-                _blockReuses++;
-                return true;
+                _freeByLength.Remove(payload.Length);
             }
 
-            // In-place overwrite refused (e.g. transaction active): keep the block free for a
-            // later write and try the next candidate; if none succeeds we fall back to append.
-            offsets.Add(offset);
-            break;
+            _cache[offset] = payload;
+            _blockReuses++;
+            return true;
         }
 
+        // In-place overwrite refused (e.g. transaction active): keep the block free for a later
+        // write and fall back to appending.
+        offsets.Add(offset);
         offset = 0;
         return false;
     }

--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -2272,8 +2272,8 @@ public partial class Table
                                     var newPkVal = row[this.Columns[this.PrimaryKeyIndex]]?.ToString() ?? string.Empty;
                                     if (!string.Equals(newPkVal, oldPkValue?.ToString(), StringComparison.Ordinal))
                                     {
-                                        if (!string.IsNullOrEmpty(oldPkValue?.ToString()))
-                                            this.Index.Delete(oldPkValue!.ToString()!);
+                                        if (oldPkValue?.ToString() is { Length: > 0 } oldPkString)
+                                            this.Index.Delete(oldPkString);
                                         if (!string.IsNullOrEmpty(newPkVal))
                                             this.Index.Insert(newPkVal, oldPosition);
                                     }
@@ -2692,12 +2692,9 @@ public partial class Table
                 // Transactional delete: buffer the physical offsets so the in-place marker is
                 // applied at COMMIT (rollback discards the buffer). Durable in O(delete) — the
                 // flush-time full-file rewrite is no longer needed for transactional deletes.
-                foreach (var position in positions)
+                foreach (var position in positions.Where(static position => position >= 0))
                 {
-                    if (position >= 0)
-                    {
-                        this.storage.BufferTombstoneForCommit(DataFile, position);
-                    }
+                    this.storage.BufferTombstoneForCommit(DataFile, position);
                 }
             }
             else
@@ -2755,10 +2752,10 @@ public partial class Table
         List<long>? remainingPositions = null;
         if (!this.storage.AreRecordsEncrypted(DataFile))
         {
-            remainingPositions = ScanLegacyPlaintextRemainingKeys(DataFile, pkCol, deletedKeys);
+            remainingPositions = ScanLegacyPlaintextRemainingKeys(DataFile, deletedKeys);
         }
 
-        remainingPositions ??= ScanLegacyRemainingKeysViaStorage(DataFile, pkCol, deletedKeys);
+        remainingPositions ??= ScanLegacyRemainingKeysViaStorage(DataFile, deletedKeys);
         if (remainingPositions is { Count: > 0 })
         {
             TombstoneDeletedPositions(remainingPositions.ToArray());
@@ -2772,7 +2769,7 @@ public partial class Table
     /// <see langword="null"/> when the raw layout could not be parsed safely (the caller then falls
     /// back to the storage-layer scan, which understands per-record encryption).
     /// </summary>
-    private List<long>? ScanLegacyPlaintextRemainingKeys(string dataFile, string pkCol, HashSet<string> deletedKeys)
+    private List<long>? ScanLegacyPlaintextRemainingKeys(string dataFile, HashSet<string> deletedKeys)
     {
         var matches = new List<long>();
         try
@@ -2822,7 +2819,7 @@ public partial class Table
                     break;
                 }
 
-                if (TryReadPrimaryKeyFromLegacyRecord(recordData, pkCol, out var pkStr) && deletedKeys.Contains(pkStr))
+                if (TryReadPrimaryKeyFromLegacyRecord(recordData, out var pkStr) && deletedKeys.Contains(pkStr))
                 {
                     matches.Add(position);
                 }
@@ -2843,12 +2840,12 @@ public partial class Table
     /// plaintext raw scan is unavailable): iterates the records through
     /// <c>storage.ReadAllRecords</c>, which decrypts payloads and already skips tombstone markers.
     /// </summary>
-    private List<long> ScanLegacyRemainingKeysViaStorage(string dataFile, string pkCol, HashSet<string> deletedKeys)
+    private List<long> ScanLegacyRemainingKeysViaStorage(string dataFile, HashSet<string> deletedKeys)
     {
         var matches = new List<long>();
-        foreach (var (recordOffset, recordData) in this.storage!.ReadAllRecords(dataFile))
+        foreach (var (recordOffset, recordData) in this.storage.ReadAllRecords(dataFile))
         {
-            if (TryReadPrimaryKeyFromLegacyRecord(recordData, pkCol, out var pkStr) && deletedKeys.Contains(pkStr))
+            if (TryReadPrimaryKeyFromLegacyRecord(recordData, out var pkStr) && deletedKeys.Contains(pkStr))
             {
                 matches.Add(recordOffset);
             }
@@ -2861,7 +2858,7 @@ public partial class Table
     /// Walks a legacy variable-length record and returns the value of the primary-key column
     /// (the same layout walk used by the reopen index rebuild).
     /// </summary>
-    private bool TryReadPrimaryKeyFromLegacyRecord(byte[] recordData, string pkCol, out string? pkValue)
+    private bool TryReadPrimaryKeyFromLegacyRecord(byte[] recordData, out string? pkValue)
     {
         pkValue = null;
         try

--- a/src/SharpCoreDB/Database/Core/Database.Core.cs
+++ b/src/SharpCoreDB/Database/Core/Database.Core.cs
@@ -35,7 +35,7 @@ public partial class Database : IDatabase, IDisposable, IAsyncDisposable
     // Diagnostics: number of DELETE statements routed through the canonical structured batch path
     // (proves the scanner/batch fast paths are engaged; 0 means everything fell back to regex).
     private static long _canonicalDeleteStatements;
-    public long CanonicalDeleteStatementsParsed => Interlocked.Read(ref _canonicalDeleteStatements);
+    public static long CanonicalDeleteStatementsParsed => Interlocked.Read(ref _canonicalDeleteStatements);
 
     private readonly IServiceProvider _serviceProvider;
     private readonly IStorage storage;

--- a/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
+++ b/tests/SharpCoreDB.Tests/FixedWidthBulkDeleteTests.cs
@@ -299,12 +299,12 @@ public sealed class FixedWidthBulkDeleteTests : IDisposable
             InsertDocs(db, 1, 50);
             db.Flush();
 
-            var before = ((SharpCoreDB.Database)db).CanonicalDeleteStatementsParsed;
+            var before = SharpCoreDB.Database.CanonicalDeleteStatementsParsed;
             db.ExecuteBatchSQL(BuildDeletes(1, 10));
             db.Flush();
 
             Assert.True(
-                ((SharpCoreDB.Database)db).CanonicalDeleteStatementsParsed >= before + 10,
+                SharpCoreDB.Database.CanonicalDeleteStatementsParsed >= before + 10,
                 "canonical DELETE statements must flow through the structured batch path");
             Assert.Equal(40, db.ExecuteQuery("SELECT id FROM docs").Count);
         }

--- a/tests/SharpCoreDB.Tests/FixedWidthRecordLayoutTests.cs
+++ b/tests/SharpCoreDB.Tests/FixedWidthRecordLayoutTests.cs
@@ -58,7 +58,7 @@ public sealed class FixedWidthRecordLayoutTests : IDisposable
             Assert.Single(row);
             Assert.Equal("beta", row[0]["name"]);
             Assert.Equal(2.5, Convert.ToDouble(row[0]["score"]));
-            Assert.Equal(false, Convert.ToBoolean(row[0]["flag"]));
+            Assert.False(Convert.ToBoolean(row[0]["flag"]));
 
             var all = db.ExecuteQuery("SELECT * FROM t ORDER BY id");
             Assert.Equal(2, all.Count);


### PR DESCRIPTION
First batch against the SonarCloud new-code issues on master (73 total):

- **BUG S1751** OverflowArena.TryReuseFreeBlock: loop could never iterate more than once -> single-attempt if (runtime-identical).
- **S1172/S8969** legacy delete-purge helpers (new code from the reopen data-integrity fix): drop unused pkCol parameter and redundant null-forgiving operators.
- **S3267** transactional delete-buffer loop -> Where.
- **S2325** Database.CanonicalDeleteStatementsParsed is static (tests updated).
- **S2701** FixedWidthRecordLayoutTests uses Assert.False.

Validated: SharpCoreDB.Tests 1777/0, CQRS 64/0.

Remaining (mostly S3776 cognitive-complexity on pre-existing large methods, 16-107) and mechanical items in benchmark/tests are tracked for follow-up batches.