### PR TITLE
sonar: fix remaining mechanical issues (batch 3)

### DIFF
--- a/src/SharpCoreDB/DataStructures/Table.CRUD.cs
+++ b/src/SharpCoreDB/DataStructures/Table.CRUD.cs
@@ -2525,13 +2525,7 @@ public partial class Table
                 continue;
             }
 
-            foreach (var colIdx in repoints)
-            {
-                if (!indexedColumns.Contains(colIdx))
-                {
-                    indexedColumns.Add(colIdx);
-                }
-            }
+            indexedColumns.AddRange(repoints.Where(colIdx => !indexedColumns.Contains(colIdx)));
         }
 
         foreach (var colIdx in indexedColumns)
@@ -3745,7 +3739,7 @@ public partial class Table
     /// whole-file snapshot. Returns null when the position/length is not fully contained in the
     /// snapshot (caller falls back to the per-record read).
     /// </summary>
-    private byte[]? TrySlicePayloadFromFile(byte[] wholeFile, long position)
+    private static byte[]? TrySlicePayloadFromFile(byte[] wholeFile, long position)
     {
         if (position < 0 || position + 4 > wholeFile.Length)
         {
@@ -3973,12 +3967,9 @@ public partial class Table
         {
             // Transactional delete: buffer the physical offsets so the in-place marker is applied
             // at COMMIT (see DeleteRecordsCore — rollback discards the buffer).
-            foreach (var position in positions)
+            foreach (var position in positions.Where(static position => position >= 0))
             {
-                if (position >= 0)
-                {
-                    this.storage.BufferTombstoneForCommit(DataFile, position);
-                }
+                this.storage.BufferTombstoneForCommit(DataFile, position);
             }
         }
         else

--- a/src/SharpCoreDB/Services/SqlParser.Core.cs
+++ b/src/SharpCoreDB/Services/SqlParser.Core.cs
@@ -311,20 +311,19 @@ public partial class SqlParser(Dictionary<string, ITable> tables, string dbPath,
             // B8: direct hash-index point lookup for `WHERE indexed_col = @param|literal`. This
             // skips building a WHERE string and re-parsing it inside SelectInternal — the single
             // biggest overhead difference vs the Direct API (FindByIndex) on point reads.
-            if (TryResolveWhereValue(simple, parameters, out var whereValue) && whereValue is not null)
+            if (TryResolveWhereValue(simple, parameters, out var whereValue) &&
+                whereValue is not null &&
+                table is DataStructures.Table concrete &&
+                concrete.TrySelectIndexedPointLookup(simple.WhereColumn, whereValue, out var indexRows))
             {
-                if (table is DataStructures.Table concrete &&
-                    concrete.TrySelectIndexedPointLookup(simple.WhereColumn, whereValue, out var indexRows))
-                {
-                    if (simple.Offset.HasValue && simple.Offset.Value > 0)
-                        indexRows = [.. indexRows.Skip(simple.Offset.Value)];
+                if (simple.Offset.HasValue && simple.Offset.Value > 0)
+                    indexRows = [.. indexRows.Skip(simple.Offset.Value)];
 
-                    if (simple.Limit.HasValue && simple.Limit.Value > 0)
-                        indexRows = [.. indexRows.Take(simple.Limit.Value)];
+                if (simple.Limit.HasValue && simple.Limit.Value > 0)
+                    indexRows = [.. indexRows.Take(simple.Limit.Value)];
 
-                    results = concrete.DeduplicateByPrimaryKey(indexRows);
-                    return true;
-                }
+                results = concrete.DeduplicateByPrimaryKey(indexRows);
+                return true;
             }
 
             // Fallback: build the WHERE string exactly like the legacy binder and let the table


### PR DESCRIPTION
Third batch against SonarCloud new-code issues:
- S1066 (SqlParser.Core): nested guard merged into the point-lookup condition.
- S3267 (Table.CRUD): repoint-column dedupe and transactional tombstone buffering simplified with Where.
- S2325 (Table.CRUD): TrySlicePayloadFromFile is now static.

Validated: SharpCoreDB.Tests 1777/0, SharpCoreDB.CQRS.Tests 64/0.