### PR TITLE
sonar: drop always-true fileLength bound (S2589)

### DIFF
--- a/src/SharpCoreDB/Services/Storage.Append.cs
+++ b/src/SharpCoreDB/Services/Storage.Append.cs
@@ -697,7 +697,7 @@ public partial class Storage
             if (offsets.Length >= 64)
             {
                 fileLength = File.Exists(path) ? new FileInfo(path).Length : 0;
-                if (fileLength > 0 && fileLength <= RangeMarkerReadLimitBytes && fileLength <= int.MaxValue)
+                if (fileLength > 0 && fileLength <= RangeMarkerReadLimitBytes)
                 {
                     wholeFile = new byte[(int)fileLength];
                     if (RandomAccess.Read(readHandle, wholeFile, 0) != fileLength)


### PR DESCRIPTION
S2589 (Storage.Append): fileLength <= int.MaxValue is always true given fileLength <= RangeMarkerReadLimitBytes (32 MB); the (int) cast is already safe.

Validated: SharpCoreDB.Tests 1777/0.